### PR TITLE
Add set_retries() in post-processing

### DIFF
--- a/eNMS/services/workflow/payload_extraction.py
+++ b/eNMS/services/workflow/payload_extraction.py
@@ -43,7 +43,7 @@ class PayloadExtractionService(Service):
             try:
                 variables = locals()
                 variables.pop("query")
-                value = run.eval(query, **variables)
+                value = run.eval(query, **variables)[0]
             except Exception as exc:
                 success = False
                 result[variable] = f"Wrong Python query for {variable} ({exc})"

--- a/eNMS/services/workflow/payload_validation.py
+++ b/eNMS/services/workflow/payload_validation.py
@@ -16,7 +16,7 @@ class PayloadValidationService(Service):
     __mapper_args__ = {"polymorphic_identity": "payload_validation_service"}
 
     def job(self, run, payload, device=None):
-        return {"query": run.query, "result": run.eval(run.query, **locals())}
+        return {"query": run.query, "result": run.eval(run.query, **locals())[0]}
 
 
 class PayloadValidationForm(ServiceForm):


### PR DESCRIPTION
set_retries() can be called during post-processing on any service to update the number of remaining retries.  Setting retries to zero stops all subsequent retries.