### PR TITLE
Adding custom CSS override to the RTD theme

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -42,3 +42,20 @@ table.docutils td {
     border-width: 1px;
     border-color: #E1E4E5;
 }
+
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+   .wy-nav-content {
+        max-width: 100% !important;
+    }
+
+    .wy-table-responsive table td, .wy-table-responsive table th {
+        white-space: normal !important;;
+    }
+
+    .wy-table-responsive {
+        overflow: visible !important;
+        max-width: 100%;
+    }
+}


### PR DESCRIPTION
Expanding width for computer screen browsers - related to https://github.com/readthedocs/sphinx_rtd_theme/issues/117 plus another stackoverflow article that also icnluded a .wy-nav-content width rule (originally: 1500px; changed to 100% here).

This should, for larger screens, allow more of the screen width to be utilized per comments from Aaron earlier today.  I had an uglier fix prior to this but was able to clean it up to this with a tiny bit of experimentation.