### PR TITLE
Add the option to skip the pool update on a migrate_import (UI, REST)

### DIFF
--- a/eNMS/controller/administration.py
+++ b/eNMS/controller/administration.py
@@ -87,6 +87,7 @@ class AdministrationController(BaseController):
 
     def migration_import(self, folder="migrations", **kwargs):
         status, models = "Import successful.", kwargs["import_export_types"]
+        skip_update_pools_after_import = kwargs.get("skip_update_pools_after_import", False)
         if kwargs.get("empty_database_before_import", False):
             for model in models:
                 delete_all(model)
@@ -110,7 +111,7 @@ class AdministrationController(BaseController):
                         workflow_services[instance["name"]] = instance.pop("services")
                     try:
                         instance = self.objectify(instance_type, instance)
-                        factory(instance_type, **instance)
+                        factory(instance_type, **{"dont_update_pools": True, **instance})
                         Session.commit()
                     except Exception:
                         info(
@@ -132,6 +133,9 @@ class AdministrationController(BaseController):
                 Session.commit()
             for service in fetch_all("service"):
                 service.set_name()
+            if not skip_update_pools_after_import:
+                for pool in fetch_all("pool"):
+                    pool.compute_pool()
             self.log("info", status)
         except Exception:
             info(chr(10).join(format_exc().splitlines()))

--- a/eNMS/forms/administration.py
+++ b/eNMS/forms/administration.py
@@ -53,6 +53,7 @@ class DatabaseMigrationsForm(BaseForm):
     template = "database_migration"
     form_type = HiddenField(default="database_migration")
     empty_database_before_import = BooleanField("Empty Database before Import")
+    skip_update_pools_after_import = BooleanField("Skip the Pool update after Import", default="checked")
     export_choices = [(p, p) for p in import_classes]
     import_export_types = SelectMultipleField(
         "Instances to migrate", choices=export_choices

--- a/eNMS/static/base.js
+++ b/eNMS/static/base.js
@@ -34,7 +34,7 @@ const panelSize = {
   compare: "auto 700",
   configuration: "800 auto",
   database_deletion: "700 400",
-  database_migration: "700 300",
+  database_migration: "700 350",
   device_connection: "400 500",
   device_results: "1200 700",
   display: "700 700",

--- a/eNMS/templates/forms/database_migration_form.html
+++ b/eNMS/templates/forms/database_migration_form.html
@@ -8,8 +8,15 @@
   <div class="modal-body">
     <div>
       <label>Empty Database before Import</label>
-      {{ form.empty_database_before_import() }}<br /><br />
-      <label>
+      {{ form.empty_database_before_import() }}
+    </div>
+    <div>
+      <label>Skip the Pool update after Import</label>
+      {{ form.skip_update_pools_after_import(checked=True) }}
+    </div>
+    <br/>
+    <div>
+    <label>
         Directory pathname to use in HOME/files/migrations :<br />
         Example: "10312018_backup"
       </label>


### PR DESCRIPTION
This is the tiny feature to allow the Pool update to optionally be skipped using either the UI or the REST API.  The new field name is **skip_update_pools_after_import** 