### PR TITLE
table filter - bool column - event handler => change 

### DIFF
--- a/eNMS/static/js/table.js
+++ b/eNMS/static/js/table.js
@@ -48,6 +48,7 @@ export function initTable(type, instance, runtime, id) {
           const data = columns[index];
           let element;
           const elementId = `${type}_filtering-${data.data}`;
+          let updateTableEvent = "keyup";
           if (data.search == "text") {
             element = `
             <div class="input-group" style="width:100%">
@@ -86,10 +87,11 @@ export function initTable(type, instance, runtime, id) {
                 <option value="bool-true">True</option>
                 <option value="bool-false">False</option>
               </select>`;
+              updateTableEvent = "change";
           }
           $(element)
             .appendTo($(this.header()))
-            .on("keyup", function() {
+            .on(updateTableEvent, function() {
               if (waitForSearch) return;
               waitForSearch = true;
               setTimeout(function() {


### PR DESCRIPTION
Issue: 
- in the Run result filtering, a change to the selected value in the "bool" search column (e.g., "Success" in a Result display) is not automatically applied.

Workaround:
- There is an existing work-around - you can push the Refresh button.

Proposed solution:
- Substituting the 'change' event handler seems to address this minor behavior

