### PR TITLE
fix rest api

### DIFF
--- a/eNMS/models/automation.py
+++ b/eNMS/models/automation.py
@@ -498,7 +498,9 @@ class Run(AbstractBase):
             ]
             return {"success": all(results), "runtime": self.runtime}
         elif self.run_method != "per_device":
-            return self.get_results(payload)
+            result = self.get_results(payload)
+            result["runtime"] = self.runtime
+            return result
         else:
 
             if self.multiprocessing and len(self.devices) > 1:


### PR DESCRIPTION
I fixed bug in API I was talking in Slack:

> Fikirsiz  11:22 PM
> I ran service with API 127.0.0.1:5000/rest/run_service ("async": true) and tried to get result with 127.0.0.1:5000/rest/result/<my service>/2020-03-03 22:59:56.642734. Work perfectly if "Run method" == "Run the service once per device", but if "Run method" == "Run the service once" I get Exception: There is no result in the database with the following characteristics: {'service_id': 3, 'runtime': '2020-03-03 22:59:56.642734'}.