### PR TITLE
Added jumpserver support to netmiko validation and prompts

### DIFF
--- a/eNMS/forms/__init__.py
+++ b/eNMS/forms/__init__.py
@@ -2,12 +2,13 @@ from collections import defaultdict
 from flask import request
 from flask_login import current_user
 from flask_wtf import FlaskForm
+from wtforms import PasswordField
 from wtforms.fields.core import UnboundField
 from wtforms.form import FormMeta
 
 from eNMS.forms.fields import field_types, InstanceField, MultipleInstanceField
 from eNMS.models import property_types, relationships
-from eNMS.properties import field_conversion, property_names
+from eNMS.properties import field_conversion, private_properties, property_names
 
 
 form_actions = {}
@@ -33,6 +34,12 @@ class MetaForm(FormMeta):
             for field_name, field in attrs.items()
             if isinstance(field, UnboundField) and field.field_class in field_types
         }
+        for field_name, field in attrs.items():
+            if not hasattr(field, "field_class"):
+                continue
+            password_field = issubclass(field.field_class, PasswordField)
+            if password_field and field_name not in private_properties:
+                private_properties.append(field_name)
         property_names.update(
             {
                 field_name: field.args[0]

--- a/eNMS/forms/automation.py
+++ b/eNMS/forms/automation.py
@@ -216,7 +216,36 @@ class NetmikoForm(ConnectionForm):
         ),
         default=1.0,
     )
+    use_jumpserver = BooleanField("Use Jump Server", default=False)
+    jump_command = SubstitutionField(
+        label="Command that jumps to device", default="ssh jump_server_IP"
+    )
+    jump_username = SubstitutionField(label="Device username")
+    jump_password = PasswordSubstitutionField(label="Device password")
+    exit_command = SubstitutionField(
+        label="Command to exit device back to jump server", default="exit",
+    )
+    expect_username_prompt = SubstitutionField(
+        "Expected username prompt", default="username:"
+    )
+    expect_password_prompt = SubstitutionField(
+        "Expected password prompt", default="password"
+    )
+    expect_prompt = SubstitutionField("Expected prompt after login", default="admin.*$")
     groups = {
+        "Jump Server Parameters": {
+            "commands": [
+                "use_jumpserver",
+                "jump_command",
+                "expect_username_prompt",
+                "jump_username",
+                "expect_password_prompt",
+                "jump_password",
+                "expect_prompt",
+                "exit_command",
+            ],
+            "default": "hidden",
+        },
         "Netmiko Parameters": {
             "commands": [
                 "driver",

--- a/eNMS/services/data_validation/netmiko_prompts.py
+++ b/eNMS/services/data_validation/netmiko_prompts.py
@@ -1,9 +1,9 @@
 from sqlalchemy import Boolean, Float, ForeignKey, Integer
 from traceback import format_exc
-from wtforms import HiddenField
+from wtforms import BooleanField, HiddenField
 
 from eNMS.database.dialect import Column, LargeString, SmallString
-from eNMS.forms.fields import SubstitutionField
+from eNMS.forms.fields import PasswordSubstitutionField, SubstitutionField
 from eNMS.forms.automation import NetmikoForm
 from eNMS.models.automation import ConnectionService
 
@@ -29,11 +29,27 @@ class NetmikoPromptsService(ConnectionService):
     timeout = Column(Integer, default=10.0)
     delay_factor = Column(Float, default=1.0)
     global_delay_factor = Column(Float, default=1.0)
+    use_jumpserver = Column(Boolean)
+    jump_command = Column(SmallString)
+    jump_username = Column(SmallString)
+    jump_password = Column(SmallString)
+    exit_command = Column(SmallString)
+    expect_username_prompt = Column(SmallString)
+    expect_password_prompt = Column(SmallString)
+    expect_prompt = Column(SmallString)
+    expect_string = Column(SmallString)
 
     __mapper_args__ = {"polymorphic_identity": "netmiko_prompts_service"}
 
     def job(self, run, payload, device):
         netmiko_connection = run.netmiko_connection(device)
+        netmiko_connection.session_log.truncate(0)
+
+        if self.use_jumpserver:
+            jumpserver_prompt, error = self.enter_jumpserver(run, netmiko_connection)
+            if error:
+                return error
+
         send_strings = (run.command, run.response1, run.response2, run.response3)
         expect_strings = (run.confirmation1, run.confirmation2, run.confirmation3, None)
         commands = []
@@ -65,7 +81,85 @@ class NetmikoPromptsService(ConnectionService):
                     {"success": False, "result": result, "match": confirmation}
                 )
                 return results
+
+        if self.use_jumpserver:
+            self.exit_jumpserver(run, netmiko_connection, jumpserver_prompt)
+
         return {"commands": commands, "result": result}
+
+    def enter_jumpserver(self, run, netmiko_connection):
+        jump_command = run.sub(run.jump_command, locals())
+        jump_username = run.sub(run.jump_username, locals())
+        jump_password = run.sub(run.jump_password, locals())
+        expect_username_prompt = run.sub(run.expect_username_prompt, locals())
+        expect_password_prompt = run.sub(run.expect_password_prompt, locals())
+        expect_prompt = run.sub(run.expect_prompt, locals())
+
+        if (
+            expect_username_prompt
+            and not jump_username
+            or expect_password_prompt
+            and not jump_password
+        ):
+            raise Exception(
+                "Jumpserver username/password is required when a username/password prompt is specified"
+            )
+
+        # Grab prompt from jumpserver for use after exit from device
+        netmiko_connection.find_prompt()
+        jumpserver_prompt = netmiko_connection.base_prompt
+
+        send_strings = (
+            text
+            for text in (jump_command, jump_username, jump_password)
+            if text not in (None, "")
+        )
+        expect_strings = (
+            text
+            for text in (expect_username_prompt, expect_password_prompt, expect_prompt)
+            if text not in (None, "")
+        )
+
+        for send_string, expect_string in zip(send_strings, expect_strings):
+            if not (send_string and expect_string):
+                return jumpserver_prompt, None
+            try:
+                netmiko_connection.send_command(
+                    send_string,
+                    expect_string=expect_string,
+                    auto_find_prompt=False,
+                    strip_prompt=False,
+                    strip_command=True,
+                    max_loops=150,  # 150 loops * .2 loop_delay = 30 second timeout
+                )
+            except Exception:
+                return (
+                    None,
+                    {
+                        "error": format_exc(),
+                        "result": (
+                            netmiko_connection.session_log.getvalue().decode()
+                            if hasattr(netmiko_connection, "session_log")
+                            else "No results available after exception. Driver does not support session_log"
+                        ),
+                        "message": f"Sent '{send_string}', waiting for '{expect_string}'",
+                        "success": False,
+                    },
+                )
+
+        return jumpserver_prompt, None
+
+    def exit_jumpserver(self, run, netmiko_connection, jumpserver_prompt):
+        exit_command = run.sub(run.exit_command, locals())
+
+        # Send exit command, wait for device prompt
+        netmiko_connection.send_command(
+            exit_command,
+            expect_string=jumpserver_prompt or None,
+            auto_find_prompt=True,
+            strip_prompt=False,
+            strip_command=True,
+        )
 
 
 class NetmikoPromptsForm(NetmikoForm):
@@ -77,6 +171,41 @@ class NetmikoPromptsForm(NetmikoForm):
     response2 = SubstitutionField()
     confirmation3 = SubstitutionField()
     response3 = SubstitutionField()
+
+    # Need to add javascript to let service editor choose a profile and
+    # populate each field from the chosen profile.
+    JUMPSERVER_DEFAULT_PROFILES = {
+        "Cisco Calvados": {
+            "jump_command": "admin",
+            "exit_command": "exit",
+            "expect_username_prompt": "Admin Username:",
+            "expect_password_prompt": "Password:",
+            "expect_prompt": "sysadmin-vm:.*#",
+        },
+    }
+
+    defaults = JUMPSERVER_DEFAULT_PROFILES["Cisco Calvados"]
+
+    use_jumpserver = BooleanField("Use Jump Server", default=False)
+    jump_command = SubstitutionField(
+        label="Command that jumps to device", default=defaults["jump_command"]
+    )
+    jump_username = SubstitutionField(label="Device username")
+    jump_password = PasswordSubstitutionField(label="Device jump_password")
+    exit_command = SubstitutionField(
+        label="Command to exit device back to jump server",
+        default=defaults["exit_command"],
+    )
+    expect_username_prompt = SubstitutionField(
+        "Expected username prompt", default=defaults["expect_username_prompt"]
+    )
+    expect_password_prompt = SubstitutionField(
+        "Expected password prompt", default=defaults["expect_password_prompt"]
+    )
+    expect_prompt = SubstitutionField(
+        "Expected prompt after login", default=defaults["expect_prompt"]
+    )
+
     groups = {
         "Main Parameters": {
             "commands": [
@@ -89,6 +218,19 @@ class NetmikoPromptsForm(NetmikoForm):
                 "response3",
             ],
             "default": "expanded",
+        },
+        "Jump Server Parameters": {
+            "commands": [
+                "use_jumpserver",
+                "jump_command",
+                "expect_username_prompt",
+                "jump_username",
+                "expect_password_prompt",
+                "jump_password",
+                "expect_prompt",
+                "exit_command",
+            ],
+            "default": "hidden",
         },
         **NetmikoForm.groups,
     }

--- a/eNMS/services/data_validation/netmiko_prompts.py
+++ b/eNMS/services/data_validation/netmiko_prompts.py
@@ -171,41 +171,6 @@ class NetmikoPromptsForm(NetmikoForm):
     response2 = SubstitutionField()
     confirmation3 = SubstitutionField()
     response3 = SubstitutionField()
-
-    # Need to add javascript to let service editor choose a profile and
-    # populate each field from the chosen profile.
-    JUMPSERVER_DEFAULT_PROFILES = {
-        "Cisco Calvados": {
-            "jump_command": "admin",
-            "exit_command": "exit",
-            "expect_username_prompt": "Admin Username:",
-            "expect_password_prompt": "Password:",
-            "expect_prompt": "sysadmin-vm:.*#",
-        },
-    }
-
-    defaults = JUMPSERVER_DEFAULT_PROFILES["Cisco Calvados"]
-
-    use_jumpserver = BooleanField("Use Jump Server", default=False)
-    jump_command = SubstitutionField(
-        label="Command that jumps to device", default=defaults["jump_command"]
-    )
-    jump_username = SubstitutionField(label="Device username")
-    jump_password = PasswordSubstitutionField(label="Device jump_password")
-    exit_command = SubstitutionField(
-        label="Command to exit device back to jump server",
-        default=defaults["exit_command"],
-    )
-    expect_username_prompt = SubstitutionField(
-        "Expected username prompt", default=defaults["expect_username_prompt"]
-    )
-    expect_password_prompt = SubstitutionField(
-        "Expected password prompt", default=defaults["expect_password_prompt"]
-    )
-    expect_prompt = SubstitutionField(
-        "Expected prompt after login", default=defaults["expect_prompt"]
-    )
-
     groups = {
         "Main Parameters": {
             "commands": [
@@ -218,19 +183,6 @@ class NetmikoPromptsForm(NetmikoForm):
                 "response3",
             ],
             "default": "expanded",
-        },
-        "Jump Server Parameters": {
-            "commands": [
-                "use_jumpserver",
-                "jump_command",
-                "expect_username_prompt",
-                "jump_username",
-                "expect_password_prompt",
-                "jump_password",
-                "expect_prompt",
-                "exit_command",
-            ],
-            "default": "hidden",
         },
         **NetmikoForm.groups,
     }

--- a/eNMS/services/data_validation/netmiko_prompts.py
+++ b/eNMS/services/data_validation/netmiko_prompts.py
@@ -149,17 +149,6 @@ class NetmikoPromptsService(ConnectionService):
 
         return jumpserver_prompt, None
 
-    def exit_jumpserver(self, run, netmiko_connection, jumpserver_prompt):
-        exit_command = run.sub(run.exit_command, locals())
-
-        # Send exit command, wait for device prompt
-        netmiko_connection.send_command(
-            exit_command,
-            expect_string=jumpserver_prompt or None,
-            auto_find_prompt=True,
-            strip_prompt=False,
-            strip_command=True,
-        )
 
 
 class NetmikoPromptsForm(NetmikoForm):

--- a/eNMS/services/data_validation/netmiko_validation.py
+++ b/eNMS/services/data_validation/netmiko_validation.py
@@ -41,16 +41,23 @@ class NetmikoValidationService(ConnectionService):
 
     def job(self, run, payload, device):
         netmiko_connection = run.netmiko_connection(device)
-
         if self.use_jumpserver:
-            jumpserver_prompt, error = self.enter_jumpserver(run, netmiko_connection)
-            if error:
-                return error
-
+            netmiko_connection.find_prompt()
+            prompt = netmiko_connection.base_prompt
+            commands = list(filter(None, [
+                run.sub(run.jump_command, locals()),
+                run.sub(run.expect_username_prompt, locals()),
+                run.sub(run.jump_username, locals()),
+                run.sub(run.expect_password_prompt, locals()),
+                run.sub(run.jump_password, locals()),
+                run.sub(run.expect_prompt, locals()),
+            ]))
+            result = self.enter_jump_server(run, netmiko_connection, commands)
+            if result:
+                return result
         command = run.sub(run.command, locals())
         run.log("info", f"Sending '{command}' with Netmiko", device)
         expect_string = run.sub(run.expect_string, locals())
-
         netmiko_connection.session_log.truncate(0)
         try:
             result = netmiko_connection.send_command(
@@ -69,85 +76,38 @@ class NetmikoValidationService(ConnectionService):
                 "result": netmiko_connection.session_log.getvalue().decode(),
                 "success": False,
             }
-
         if self.use_jumpserver:
-            self.exit_jumpserver(run, netmiko_connection, jumpserver_prompt)
-
+            exit_command = run.sub(run.exit_command, locals())
+            netmiko_connection.send_command(
+                exit_command,
+                expect_string=prompt or None,
+                auto_find_prompt=True,
+                strip_prompt=False,
+                strip_command=True,
+            )
         return {"command": command, "result": result}
 
-    def enter_jumpserver(self, run, netmiko_connection):
-        jump_command = run.sub(run.jump_command, locals())
-        jump_username = run.sub(run.jump_username, locals())
-        jump_password = run.sub(run.jump_password, locals())
-        expect_username_prompt = run.sub(run.expect_username_prompt, locals())
-        expect_password_prompt = run.sub(run.expect_password_prompt, locals())
-        expect_prompt = run.sub(run.expect_prompt, locals())
-
-        if (
-            expect_username_prompt
-            and not jump_username
-            or expect_password_prompt
-            and not jump_password
-        ):
-            raise Exception(
-                "Jumpserver username/password is required when a username/password prompt is specified"
-            )
-
-        # Grab prompt from jumpserver for use after exit from device
-        netmiko_connection.find_prompt()
-        jumpserver_prompt = netmiko_connection.base_prompt
-
-        send_strings = (
-            text
-            for text in (jump_command, jump_username, jump_password)
-            if text not in (None, "")
-        )
-        expect_strings = (
-            text
-            for text in (expect_username_prompt, expect_password_prompt, expect_prompt)
-            if text not in (None, "")
-        )
-
-        for send_string, expect_string in zip(send_strings, expect_strings):
-            if not (send_string and expect_string):
-                return jumpserver_prompt, None
+    def enter_jump_server(self, run, netmiko_connection, commands):
+        for (send, expect) in zip(commands[::2], commands[1::2]):
+            if not send or not expect:
+                continue
             try:
                 netmiko_connection.send_command(
-                    send_string,
-                    expect_string=expect_string,
+                    send,
+                    expect_string=expect,
                     auto_find_prompt=False,
                     strip_prompt=False,
                     strip_command=True,
-                    max_loops=150,  # 150 loops * .2 loop_delay = 30 second timeout
+                    max_loops=150,
                 )
             except Exception:
-                return (
-                    None,
-                    {
-                        "error": format_exc(),
-                        "result": (
-                            netmiko_connection.session_log.getvalue().decode()
-                            if hasattr(netmiko_connection, "session_log")
-                            else "No results available after exception. Driver does not support session_log"
-                        ),
-                        "message": f"Sent '{send_string}', waiting for '{expect_string}'",
-                        "success": False,
-                    },
-                )
-
-        return jumpserver_prompt, None
-
-    def exit_jumpserver(self, run, netmiko_connection, jumpserver_prompt):
-        exit_command = run.sub(run.exit_command, locals())
-
-        # Send exit command, wait for device prompt
-        netmiko_connection.send_command(
-            exit_command,
-            expect_string=jumpserver_prompt or None,
-            auto_find_prompt=True,
-            strip_prompt=False,
-            strip_command=True,
-        )
+                return {
+                    "command": send,
+                    "error": format_exc(),
+                    "result": netmiko_connection.session_log.getvalue().decode(),
+                    "message": f"Sent '{send}', waiting for '{expect}'",
+                    "success": False,
+                }
 
 
 class NetmikoValidationForm(NetmikoForm):

--- a/eNMS/services/data_validation/netmiko_validation.py
+++ b/eNMS/services/data_validation/netmiko_validation.py
@@ -3,7 +3,7 @@ from traceback import format_exc
 from wtforms import BooleanField, HiddenField
 
 from eNMS.database.dialect import Column, LargeString, SmallString
-from eNMS.forms.fields import SubstitutionField
+from eNMS.forms.fields import PasswordSubstitutionField, SubstitutionField
 from eNMS.forms.automation import NetmikoForm
 from eNMS.models.automation import ConnectionService
 
@@ -23,6 +23,14 @@ class NetmikoValidationService(ConnectionService):
     timeout = Column(Float, default=10.0)
     delay_factor = Column(Float, default=1.0)
     global_delay_factor = Column(Float, default=1.0)
+    use_jumpserver = Column(Boolean)
+    jump_command = Column(SmallString)
+    jump_username = Column(SmallString)
+    jump_password = Column(SmallString)
+    exit_command = Column(SmallString)
+    expect_username_prompt = Column(SmallString)
+    expect_password_prompt = Column(SmallString)
+    expect_prompt = Column(SmallString)
     expect_string = Column(SmallString)
     auto_find_prompt = Column(Boolean, default=True)
     strip_prompt = Column(Boolean, default=True)
@@ -33,9 +41,16 @@ class NetmikoValidationService(ConnectionService):
 
     def job(self, run, payload, device):
         netmiko_connection = run.netmiko_connection(device)
+
+        if self.use_jumpserver:
+            jumpserver_prompt, error = self.enter_jumpserver(run, netmiko_connection)
+            if error:
+                return error
+
         command = run.sub(run.command, locals())
         run.log("info", f"Sending '{command}' with Netmiko", device)
         expect_string = run.sub(run.expect_string, locals())
+
         netmiko_connection.session_log.truncate(0)
         try:
             result = netmiko_connection.send_command(
@@ -54,12 +69,124 @@ class NetmikoValidationService(ConnectionService):
                 "result": netmiko_connection.session_log.getvalue().decode(),
                 "success": False,
             }
+
+        if self.use_jumpserver:
+            self.exit_jumpserver(run, netmiko_connection, jumpserver_prompt)
+
         return {"command": command, "result": result}
+
+    def enter_jumpserver(self, run, netmiko_connection):
+        jump_command = run.sub(run.jump_command, locals())
+        jump_username = run.sub(run.jump_username, locals())
+        jump_password = run.sub(run.jump_password, locals())
+        expect_username_prompt = run.sub(run.expect_username_prompt, locals())
+        expect_password_prompt = run.sub(run.expect_password_prompt, locals())
+        expect_prompt = run.sub(run.expect_prompt, locals())
+
+        if (
+            expect_username_prompt
+            and not jump_username
+            or expect_password_prompt
+            and not jump_password
+        ):
+            raise Exception(
+                "Jumpserver username/password is required when a username/password prompt is specified"
+            )
+
+        # Grab prompt from jumpserver for use after exit from device
+        netmiko_connection.find_prompt()
+        jumpserver_prompt = netmiko_connection.base_prompt
+
+        send_strings = (
+            text
+            for text in (jump_command, jump_username, jump_password)
+            if text not in (None, "")
+        )
+        expect_strings = (
+            text
+            for text in (expect_username_prompt, expect_password_prompt, expect_prompt)
+            if text not in (None, "")
+        )
+
+        for send_string, expect_string in zip(send_strings, expect_strings):
+            if not (send_string and expect_string):
+                return jumpserver_prompt, None
+            try:
+                netmiko_connection.send_command(
+                    send_string,
+                    expect_string=expect_string,
+                    auto_find_prompt=False,
+                    strip_prompt=False,
+                    strip_command=True,
+                    max_loops=150,  # 150 loops * .2 loop_delay = 30 second timeout
+                )
+            except Exception:
+                return (
+                    None,
+                    {
+                        "error": format_exc(),
+                        "result": (
+                            netmiko_connection.session_log.getvalue().decode()
+                            if hasattr(netmiko_connection, "session_log")
+                            else "No results available after exception. Driver does not support session_log"
+                        ),
+                        "message": f"Sent '{send_string}', waiting for '{expect_string}'",
+                        "success": False,
+                    },
+                )
+
+        return jumpserver_prompt, None
+
+    def exit_jumpserver(self, run, netmiko_connection, jumpserver_prompt):
+        exit_command = run.sub(run.exit_command, locals())
+
+        # Send exit command, wait for device prompt
+        netmiko_connection.send_command(
+            exit_command,
+            expect_string=jumpserver_prompt or None,
+            auto_find_prompt=True,
+            strip_prompt=False,
+            strip_command=True,
+        )
 
 
 class NetmikoValidationForm(NetmikoForm):
     form_type = HiddenField(default="netmiko_validation_service")
     command = SubstitutionField()
+
+    # Need to add javascript to let service editor choose a profile and
+    # populate each field from the chosen profile.
+    JUMPSERVER_DEFAULT_PROFILES = {
+        "Cisco Calvados": {
+            "jump_command": "admin",
+            "exit_command": "exit",
+            "expect_username_prompt": "Admin Username:",
+            "expect_password_prompt": "Password:",
+            "expect_prompt": "sysadmin-vm:.*#",
+        },
+    }
+
+    defaults = JUMPSERVER_DEFAULT_PROFILES["Cisco Calvados"]
+
+    use_jumpserver = BooleanField("Use Jump Server", default=False)
+    jump_command = SubstitutionField(
+        label="Command that jumps to device", default=defaults["jump_command"]
+    )
+    jump_username = SubstitutionField(label="Device username")
+    jump_password = PasswordSubstitutionField(label="Device password")
+    exit_command = SubstitutionField(
+        label="Command to exit device back to jump server",
+        default=defaults["exit_command"],
+    )
+    expect_username_prompt = SubstitutionField(
+        "Expected username prompt", default=defaults["expect_username_prompt"]
+    )
+    expect_password_prompt = SubstitutionField(
+        "Expected password prompt", default=defaults["expect_password_prompt"]
+    )
+    expect_prompt = SubstitutionField(
+        "Expected prompt after login", default=defaults["expect_prompt"]
+    )
     expect_string = SubstitutionField()
     auto_find_prompt = BooleanField(default=True)
     strip_prompt = BooleanField(default=True)
@@ -74,6 +201,19 @@ class NetmikoValidationForm(NetmikoForm):
                 "strip_prompt",
                 "strip_command",
                 "use_genie",
+            ],
+            "default": "hidden",
+        },
+        "Jump Server Parameters": {
+            "commands": [
+                "use_jumpserver",
+                "jump_command",
+                "expect_username_prompt",
+                "jump_username",
+                "expect_password_prompt",
+                "jump_password",
+                "expect_prompt",
+                "exit_command",
             ],
             "default": "hidden",
         },

--- a/eNMS/services/data_validation/netmiko_validation.py
+++ b/eNMS/services/data_validation/netmiko_validation.py
@@ -153,40 +153,6 @@ class NetmikoValidationService(ConnectionService):
 class NetmikoValidationForm(NetmikoForm):
     form_type = HiddenField(default="netmiko_validation_service")
     command = SubstitutionField()
-
-    # Need to add javascript to let service editor choose a profile and
-    # populate each field from the chosen profile.
-    JUMPSERVER_DEFAULT_PROFILES = {
-        "Cisco Calvados": {
-            "jump_command": "admin",
-            "exit_command": "exit",
-            "expect_username_prompt": "Admin Username:",
-            "expect_password_prompt": "Password:",
-            "expect_prompt": "sysadmin-vm:.*#",
-        },
-    }
-
-    defaults = JUMPSERVER_DEFAULT_PROFILES["Cisco Calvados"]
-
-    use_jumpserver = BooleanField("Use Jump Server", default=False)
-    jump_command = SubstitutionField(
-        label="Command that jumps to device", default=defaults["jump_command"]
-    )
-    jump_username = SubstitutionField(label="Device username")
-    jump_password = PasswordSubstitutionField(label="Device password")
-    exit_command = SubstitutionField(
-        label="Command to exit device back to jump server",
-        default=defaults["exit_command"],
-    )
-    expect_username_prompt = SubstitutionField(
-        "Expected username prompt", default=defaults["expect_username_prompt"]
-    )
-    expect_password_prompt = SubstitutionField(
-        "Expected password prompt", default=defaults["expect_password_prompt"]
-    )
-    expect_prompt = SubstitutionField(
-        "Expected prompt after login", default=defaults["expect_prompt"]
-    )
     expect_string = SubstitutionField()
     auto_find_prompt = BooleanField(default=True)
     strip_prompt = BooleanField(default=True)
@@ -201,19 +167,6 @@ class NetmikoValidationForm(NetmikoForm):
                 "strip_prompt",
                 "strip_command",
                 "use_genie",
-            ],
-            "default": "hidden",
-        },
-        "Jump Server Parameters": {
-            "commands": [
-                "use_jumpserver",
-                "jump_command",
-                "expect_username_prompt",
-                "jump_username",
-                "expect_password_prompt",
-                "jump_password",
-                "expect_prompt",
-                "exit_command",
             ],
             "default": "hidden",
         },


### PR DESCRIPTION
Added a Jumpserver group to netmiko_validation and netmiko_prompts that accepts parameters for how to jump from the target device to a remote.  When use_jumpserver is false, no behavior is affected.