### PR TITLE
Reply to

### DIFF
--- a/docs/automation/services.rst
+++ b/docs/automation/services.rst
@@ -137,16 +137,21 @@ You can configure the following parameters:
 - ``Notification header`` A header displayed at the beginning of the notification.
 - ``Include Result Link in summary``: whether the notification contains a link to the results.
 - ``Mail recipients`` Must be a list of email addresses, separated by comma.
+- ``Reply to`` Must be a single email address
 - ``Display only failed nodes`` the notification will not include devices for which the service ran successfully.
 
 To set up the mail system, you must set the variable of the ``mail`` section in the settings.
-``server``, ``port``, ``use_tls``, ``username``, ``sender``, ``recipients``.
+``server``, ``port``, ``use_tls``, ``username``, ``sender``, ``reply_to``, ``recipients``.
 Besides, you must set the password via the ``MAIL_PASSWORD`` environment variable.
 
 The ``Mail Recipients`` parameter must be set for the mail system to work; the `Admin / Administration` panel parameter can
 also be overriden from Step2 of the Service Instance and Workflow configuration panels. For Mail notification, there is
 also an option in the Service Instance configuration to display only failed objects in the email summary versus seeing a
 list of all passed and failed objects.
+
+The ``Reply to`` must also be set for the system to work. This parameter can be overridden in Step2 of the Service Instance
+and Workflow configuration panels. The Mail Notification service will also use the system level reply address unless it is
+overriden. 
 
 In Mattermost, if the ``Mattermost Channel`` is not set, the default ``Town Square`` will be used.
 
@@ -225,6 +230,7 @@ Variables
   - ``content`` (mandatory, type ``string``)
   - ``sender`` (optional, type ``string``) Email address of the sender. Default to the sender address
     of eNMS settings.
+  - ``reply_to`` (optional, type ``string``) Email address to send replies to. 
   - ``recipients`` (optional, type ``string``) Mail addresses of the recipients, separated by comma.
     Default to the recipients addresses of eNMS settings.
   - ``filename`` (optional, type ``string``) Name of the attached file.
@@ -236,6 +242,7 @@ Variables
         title,
         content,
         sender=sender,
+        reply_to=reply_to,
         recipients=recipients,
         filename=filename,
         file_content=file_content

--- a/eNMS/controller/base.py
+++ b/eNMS/controller/base.py
@@ -444,16 +444,19 @@ class BaseController:
         subject,
         content,
         recipients="",
+        reply_to=None,
         sender=None,
         filename=None,
         file_content=None,
     ):
         sender = sender or self.settings["mail"]["sender"]
+        reply_to = reply_to or self.settings["mail"]["reply_to"]
         message = MIMEMultipart()
         message["From"] = sender
         message["To"] = recipients
         message["Date"] = formatdate(localtime=True)
         message["Subject"] = subject
+        message.add_header("reply-to", reply_to)
         message.attach(MIMEText(content))
         if filename:
             attached_file = MIMEApplication(file_content, Name=filename)

--- a/eNMS/forms/automation.py
+++ b/eNMS/forms/automation.py
@@ -48,6 +48,7 @@ class ServiceForm(BaseForm):
     include_link_in_summary = BooleanField("Include Result Link in Summary")
     display_only_failed_nodes = BooleanField("Display only Failed Devices")
     mail_recipient = StringField("Mail Recipients (separated by comma)")
+    reply_to = StringField("Reply-to Email Address")
     number_of_retries = IntegerField("Number of retries", default=0)
     time_between_retries = IntegerField("Time between retries (in seconds)", default=10)
     max_number_of_retries = IntegerField("Maximum number of retries", default=100)

--- a/eNMS/models/automation.py
+++ b/eNMS/models/automation.py
@@ -82,6 +82,7 @@ class Service(AbstractBase):
     include_device_results = db.Column(Boolean, default=True)
     include_link_in_summary = db.Column(Boolean, default=True)
     mail_recipient = db.Column(db.SmallString)
+    reply_to = db.Column(db.SmallString)
     initial_payload = db.Column(db.Dict)
     skip = db.Column(Boolean, default=False)
     skip_query = db.Column(db.LargeString)
@@ -837,6 +838,7 @@ class Run(AbstractBase):
                     f"{status}: {self.service.name}",
                     app.str_dict(notification),
                     recipients=self.mail_recipient,
+                    reply_to=self.reply_to,
                     filename=f"results-{filename}.txt",
                     file_content=app.str_dict(file_content),
                 )

--- a/eNMS/services/notification/mail_notification.py
+++ b/eNMS/services/notification/mail_notification.py
@@ -16,6 +16,7 @@ class MailNotificationService(Service):
     title = db.Column(db.SmallString)
     sender = db.Column(db.SmallString)
     recipients = db.Column(db.SmallString)
+    replier = db.Column(db.SmallString, default="")
     body = db.Column(db.LargeString, default="")
 
     __mapper_args__ = {"polymorphic_identity": "mail_notification_service"}
@@ -26,6 +27,7 @@ class MailNotificationService(Service):
             run.sub(run.body, locals()),
             sender=run.sender,
             recipients=run.recipients,
+            reply_to=run.replier,
         )
         return {"success": True, "result": {}}
 
@@ -35,6 +37,7 @@ class MailNotificationForm(ServiceForm):
     title = StringField(substitution=True)
     sender = StringField()
     recipients = StringField()
+    replier = StringField("Reply-to Address")
     body = StringField(widget=TextArea(), render_kw={"rows": 5}, substitution=True)
 
     def validate(self):

--- a/eNMS/templates/forms/service.html
+++ b/eNMS/templates/forms/service.html
@@ -772,6 +772,11 @@
                   {{ form.mail_recipient(id=form_type + '-mail_recipient',
                   class="form-control add-id") }}
                 </div>
+                {{ form.reply_to.label() }}
+                <div class="form-group">
+                  {{ form.reply_to(id=form_type + '-reply_to',
+                  class="form-control add-id") }}
+                </div>
                 <fieldset>
                   <div class="item">
                     <input

--- a/setup/settings.json
+++ b/setup/settings.json
@@ -32,7 +32,8 @@
     "port": 587,
     "use_tls": true,
     "username": "eNMS-user",
-    "sender": "eNMS@company.com"
+    "sender": "eNMS@company.com",
+    "reply_to": "reply_to@company.com",
   },
   "mattermost": {
     "url": "https://mattermost.company.com/hooks/i1phfh6fxjfwpy586bwqq5sk8w",


### PR DESCRIPTION
This adds a reply_to address into the site level settings.json and allows for users to specify a reply_to address in their services. When running services, groups responsible for specific services can get replies on their work, or use a no_reply@company.com to ignore replies to their service notification. 

Step 2 of each service now will include a reply_to address and the Mail notification service also has a reply_to field available. 