### PR TITLE
Reply to 

### DIFF
--- a/docs/automation/services.rst
+++ b/docs/automation/services.rst
@@ -227,6 +227,7 @@ Variables
     of eNMS settings.
   - ``recipients`` (optional, type ``string``) Mail addresses of the recipients, separated by comma.
     Default to the recipients addresses of eNMS settings.
+  - ``reply_to`` (optional, type ``string``) Single mail address for replies to notifications
   - ``filename`` (optional, type ``string``) Name of the attached file.
   - ``file_content`` (optional, type ``string``) Content of the attached file.
 
@@ -237,6 +238,7 @@ Variables
         content,
         sender=sender,
         recipients=recipients,
+        reply_to=reply_to,
         filename=filename,
         file_content=file_content
     )

--- a/eNMS/controller/base.py
+++ b/eNMS/controller/base.py
@@ -450,7 +450,7 @@ class BaseController:
         file_content=None,
     ):
         sender = sender or self.settings["mail"]["sender"]
-        reply_to = reply__to or self.settings["mail"]["reply_to"]
+        reply_to = reply_to or self.settings["mail"]["reply_to"]
         message = MIMEMultipart()
         message["From"] = sender
         message["To"] = recipients

--- a/eNMS/controller/base.py
+++ b/eNMS/controller/base.py
@@ -444,16 +444,19 @@ class BaseController:
         subject,
         content,
         recipients="",
+        reply_to=None,
         sender=None,
         filename=None,
         file_content=None,
     ):
         sender = sender or self.settings["mail"]["sender"]
+        reply_to = reply__to or self.settings["mail"]["reply_to"]
         message = MIMEMultipart()
         message["From"] = sender
         message["To"] = recipients
         message["Date"] = formatdate(localtime=True)
         message["Subject"] = subject
+        message.add_header("reply-to", reply_to)
         message.attach(MIMEText(content))
         if filename:
             attached_file = MIMEApplication(file_content, Name=filename)

--- a/eNMS/forms/automation.py
+++ b/eNMS/forms/automation.py
@@ -48,6 +48,7 @@ class ServiceForm(BaseForm):
     include_link_in_summary = BooleanField("Include Result Link in Summary")
     display_only_failed_nodes = BooleanField("Display only Failed Devices")
     mail_recipient = StringField("Mail Recipients (separated by comma)")
+    reply_to = StringField("Reply-to Email Address")
     number_of_retries = IntegerField("Number of retries", default=0)
     time_between_retries = IntegerField("Time between retries (in seconds)", default=10)
     max_number_of_retries = IntegerField("Maximum number of retries", default=100)

--- a/eNMS/models/automation.py
+++ b/eNMS/models/automation.py
@@ -838,7 +838,7 @@ class Run(AbstractBase):
                     f"{status}: {self.service.name}",
                     app.str_dict(notification),
                     recipients=self.mail_recipient,
-                    reply_to=run.replier,
+                    reply_to=self.reply_to,
                     filename=f"results-{filename}.txt",
                     file_content=app.str_dict(file_content),
                 )

--- a/eNMS/models/automation.py
+++ b/eNMS/models/automation.py
@@ -82,6 +82,7 @@ class Service(AbstractBase):
     include_device_results = db.Column(Boolean, default=True)
     include_link_in_summary = db.Column(Boolean, default=True)
     mail_recipient = db.Column(db.SmallString)
+    reply_to = db.Column(db.SmallString)
     initial_payload = db.Column(db.Dict)
     skip = db.Column(Boolean, default=False)
     skip_query = db.Column(db.LargeString)
@@ -837,6 +838,7 @@ class Run(AbstractBase):
                     f"{status}: {self.service.name}",
                     app.str_dict(notification),
                     recipients=self.mail_recipient,
+                    reply_to=run.replier,
                     filename=f"results-{filename}.txt",
                     file_content=app.str_dict(file_content),
                 )

--- a/eNMS/services/notification/mail_notification.py
+++ b/eNMS/services/notification/mail_notification.py
@@ -16,6 +16,7 @@ class MailNotificationService(Service):
     title = db.Column(db.SmallString)
     sender = db.Column(db.SmallString)
     recipients = db.Column(db.SmallString)
+    replier = db.Column(db.SmallString, default="")
     body = db.Column(db.LargeString, default="")
 
     __mapper_args__ = {"polymorphic_identity": "mail_notification_service"}
@@ -26,6 +27,7 @@ class MailNotificationService(Service):
             run.sub(run.body, locals()),
             sender=run.sender,
             recipients=run.recipients,
+            reply_to=run.replier,
         )
         return {"success": True, "result": {}}
 
@@ -35,6 +37,7 @@ class MailNotificationForm(ServiceForm):
     title = StringField(substitution=True)
     sender = StringField()
     recipients = StringField()
+    replier = StringField("Reply-to Address")
     body = StringField(widget=TextArea(), render_kw={"rows": 5}, substitution=True)
 
     def validate(self):

--- a/eNMS/templates/forms/service.html
+++ b/eNMS/templates/forms/service.html
@@ -772,6 +772,11 @@
                   {{ form.mail_recipient(id=form_type + '-mail_recipient',
                   class="form-control add-id") }}
                 </div>
+                {{ form.reply_to.label() }}
+                <div class="form-group">
+                  {{ form.reply_to(id=form_type + '-reply_to',
+                  class="form-control add-id") }}
+                </div>
                 <fieldset>
                   <div class="item">
                     <input

--- a/setup/settings.json
+++ b/setup/settings.json
@@ -32,7 +32,8 @@
     "port": 587,
     "use_tls": true,
     "username": "eNMS-user",
-    "sender": "eNMS@company.com"
+    "sender": "eNMS@company.com",
+    "reply_to": "reply_to@company.com"
   },
   "mattermost": {
     "url": "https://mattermost.company.com/hooks/i1phfh6fxjfwpy586bwqq5sk8w",


### PR DESCRIPTION
This adds a global reply_to to the site settings and sets up a reply_to field in step2 of the services form as well as the mail_notification_service. 

This will allow each user to get replies to their own service notification sent to any desired email address. 