### PR TITLE
Documentation updates

### DIFF
--- a/docs/advanced/administration.rst
+++ b/docs/advanced/administration.rst
@@ -5,121 +5,142 @@ Administration
 Changelog
 ---------
 
-eNMS keeps of changelog available in "Home / Changelog".
+eNMS changelog feature can be found under :guilabel:`Home / Changelog`.
 
-.. image:: /_static/administration/changelog.png
+.. image:: /_static/advanced/administration/changelog.png
    :alt: Filtering System.
    :align: center
 
-This changelog contains:
+Changelog contains searchable information, search on:
 
-- All creation and deletion of model instances.
-- All modification of these instances (which properties were modified: old value and new value).
-- All runs: what services / workflows were run, when, who started them.
-- Various administration logs such as database migration, parameters update, etc.
-
-Custom properties
------------------
+- All types of creation and deletion related activity of objects supported by the application
+- Modification activity, made to objects (e.g updates of values, naming etc.)
+- Running of services / workflows; when they ran, who ran them
+- Various administration logs, such as database migration, parameters update, etc.
+- Custom logs, defined in services / workflows
 
 Custom Properties
------------------
+--------------------
 
-You can extend the properties of a device with your own properties. Custom properties are read
-from the ``properties.json`` file in the ``setup`` folder.
-with the following variables:
+Properties of devices can be managed or extended with your own "custom" properties. Customized properties are read
+from the ``properties.json`` file in the ``setup`` folder, with the following variables:
 
   - ``type`` (**mandatory**): ``string``, ``integer``, ``float``, and ``boolean``
-  - ``pretty_name`` (**optional**): Name of the property in the UI.
-  - ``default`` (**optional**): Default value.
-  - ``add_to_dashboard`` (**optional**): Whether the property should appear in the dashboard or not.
-  - ``private`` (**optional**): If ``true``, the value is considered sensitive: it will not be displayed in the UI,
-    will be encrypted in the database and stored in the Vault if a Vault has been set up.
+  - ``pretty_name`` (**optional**): Custom name of the property in the UI
+  - ``default`` (**optional**): Default value
+  - ``add_to_dashboard`` (**optional**): Set to ``true``, to allow the property to appear in the dashboard
+  - ``private`` (**optional**): If ``true``, the value is considered sensitive: it will not be displayed in the UI.
+    It will be encrypted in the database and stored in the Vault (if the Vault has been set up)
   - ``is_address`` (**optional**): Set to ``true`` if you want to property to be usable by GoTTY to
-    connect to network devices (e.g hostnames, IP adddresses, etc)
+    connect to network devices (e.g hostnames, IP addresses, etc)
 
-.. note:: Custom properties must be defined once and for all before eNMS starts for the time,
-  as they are part of the database schema.
+.. note:: Customized properties are defined ONCE, prior to eNMS starting up for the first time, since they are mapped
+   into the database schema.  Changes to customized properties require the database to be altered or dropped and reloaded
+   to allow the object relational mapping to recreate the schema.
 
 Credentials
 -----------
 
-Credentials are stored in a Hashicorp Vault, or in the database if no Vault has been configured.
-If you are using eNMS in production, it is recommended to set up a Hashicorp Vault to handle the storage of all credentials.
+All Credentials are stored in a Vault or in the database if a Vault has not been configured. For a production eNMS
+system, a Hashicorp Vault is recommended.
 
-- User credentials can be used to authenticate to eNMS, as well as to authenticate to a network device.
-- Device credentials are a property of the device itself within the inventory. The credentials of a device are a ``username``, a ``password``, and an ``enable password`` required on some devices to enter the "enable" mode.
+- User credentials can be used to authenticate to eNMS, as well as to authenticate to a network device
+- Device credentials are properties of the device, consisting of ``username``, ``password`` and ``enable password``, (required
+  on some devices to enter the "enable" mode)
     
 .. image:: /_static/advanced/administration/credentials.png
    :alt: Set password
    :align: center
 
-Database
-********
-
-Migration, Backup, and Restore
-------------------------------
+Database: Migration, Backup and Restore
+---------------------------------------
 
 The eNMS migration system handles exporting the complete database content into YAML files.
 By providing a directory name and selecting which eNMS object types to export/backup,
-eNMS serializes the stored objects in the directory ``eNMS/files/migrations/project_name``.
+eNMS serializes the stored objects in the directory ``eNMS/files/migrations/directory_name``.
 These yaml files can then be copied into the same directory on a new VM instance of eNMS,
 and then the Import function can be used to import/restore the configuration and living data of
 those object types.
 These migration files are used for migrating from one version of eNMS to the next version. 
 They are also used for Backup and Restore of eNMS.
-The migration system is accessed from the :guilabel:`Admin / Administration` or from the REST API.
+The migration system is accessed from the :guilabel:`Admin` icon at the top of the UI or from the REST API.
 
-.. image:: /_static/administration/administration/migrations.png
+.. image:: /_static/advanced/administration/migrations.png
    :alt: Migrations
    :align: center
 
-When creating a new instance of eNMS:
-  - Install eNMS.
-  - Run the :guilabel:`Admin / Administration / Migration` either from the UI or from the REST API. Select 'Empty_database_before_import' = True, specify
-    the location of the file to import, and select all object types to be imported: "user", "device", "link", "pool", "service", "workflow_edge", "task"
+- ``Migration Import/Export`` Restore/Import database on a newly created instance of eNMS:
 
-When backing up eNMS, it is only necessary to perform :guilabel:`Admin / Administration / Migration` either from the UI or from the REST API.
-  - Select a directory name for storing the migration files into, and select all object types to Export
-  - the Topology Export of device and link data from :guilabel:`Admin / Administration / Topology Import` and :guilabel:`Admin / Administration / Topology Export` is not needed for Backup.
-    It is intended for sharing of device and link data.
+- Launch the GUI and login into a freshly built/installed eNMS system
+- Ensure that the migration YAML files are present in the desired folder
+- At the top of the UI screen, Click the :guilabel:`Admin` button
+- Click ``Migration Import/Export`` and select options, all the object types from drop down menu and the directory of
+  where the migration YAML files are kept and select Import
+- Alternatively, from the REST API, Select 'Empty_database_before_import' = True, specify the location of the directory
+  to import from, select all object types to be imported: "user", "device", "link", "pool", "service", "workflow_edge", "task"
 
-.. note:: the exported backup files do not contain the secure credentials for each of the inventory devices in plain text, as credentials are considered to be stored in a Vault in production mode.
+- ``Migration Import/Export`` Backing/Exporting database on an existing eNMS:
 
-.. note:: If you are migrating data on an existing instance of eNMS, you can choose tick the option ``Empty Database before Import`` to empty the database before starting the migration.
+- Launch the GUI and login into an existing eNMS system
+- At the top of the UI screen, Click the :guilabel:`Admin` button
+- Click ``Migration Import/Export`` and select all the object types from the drop down menu and select Export
+
+.. note:: Exported backup files do not contain the secure credentials for each of the inventoried devices in plain text.
+   The credentials are considered to be stored in a Vault in production mode.
+
+.. note:: If you are migrating data onto an existing instance (as opposed to a fresh instance) of eNMS, you can select
+   the option ``Empty Database before Import`` to empty the database before starting the migration.
 
 .. note:: See additional discussion of migration in the Installation Section
+
+- ``Per-type Mass Deletion``: Select object type(s) to be deleted
+- ``Import Service``: Services and workflow can be exported and imported individually (as a .tgz archive); There may be
+  a need to send a service / workflow from one VM to another. First, move the archive to the `files/services` folder, Click
+  the :guilabel:`Admin` button, click on the ``Import services`` button and select the service from the drop down menu
+- ``Delete Results/Logs``: Will allow historical results, logs, and changelog to be deleted
+- ``Delete Corrupted Edges``: Scans workflows to find duplicate edges between services or reference to an edge between
+  services where a service does not exist and then deletes them
 
 Miscellaneous
 -------------
 
-- ``Fetch Git Configurations and Update Devices``: this feature will retrieve configurations from the git 'configurations' repository and load those into the database for each matching inventory device. This is performed automatically when eNMS starts up: the git configurations repository is quietly cloned and loaded into the database. This feature allows for manual pulling of updated configurations data.
-- ``Pause and Resume Scheduler``: this feature will pause and resume all scheduler tasks currently waiting to run.
-- ``Reset Service Statuses``: when a service or workflow fails, it is sometimes stuck in a "Running" mode and cannot be executed. This button will reset the status of all services and workflows.
+- ``Fetch Git Configurations``: Will retrieve configurations from the git 'configurations' repository and load those into
+  the database for each matching inventory device. This is performed automatically when eNMS starts up: the git
+  configurations repository is quietly cloned and loaded into the database. This feature allows manual pulling of updated
+  configurations data
+- ``Scan Cluster Subnet``: Will populate the ``Admin -> Servers`` table with related VMs where eNMS has been deployed as
+  a cluster of Servers
 
-Individual export
------------------
+Inventory
+---------
+eNMS inventory, devices and links, can be exported and Imported into an Excel based format. When executing an exporting
+function, the file will be exported to a folder, local to the VM. When executing an importing function, the application
+will request for the desired file, local to the workstation/laptop.
+file,
 
-Services and workflows can be exported and imported individually, as a .tgz archive.
-This is useful when you have multiple VMs deployed with eNMS, and you need to send a service / workflow from one VM to another.
-
-To import a service, you need to move the archive to the ``files/services`` folder,
-then go to the "Administration" page and click on the ``Import services`` button.
+- ``Excel Import``: Will import the excel file from your local workstation or laptop
+- ``Excel Export``: Will export the excel file onto your VM, in the directory ``eNMS/files/spreadsheets``
 
 
-CLI interface
--------------
+Local Server CLI interface
+--------------------------
 
-eNMS has a CLI interface with the following operations:
+The local VM terminal can be used as a CLI interface, that interacts with the eNMS application. The prerequisite is to
+ensure that you are in the correct application directory and to deactivate any specific proxy settings. The proxy settings
+are company specified and will prevent commands from running. The user can now "ssh" into the VM and perform the following
+operations:
 
 Run a service
 *************
 
-General syntax: ``flask start service_name --devices list_of_devices --payload 'payload'`` where:
+If a service has been created on the application, the user can run a service via this CLI Interface.
 
-- list_of_devices is a list of device name separated by commas.
-- payload is a JSON dictionary.
+General syntax:
+  ``flask run_service <service_name> --devices <list_of_devices> --payload '{json dict}'``
 
-Both devices and payload are optional parameters.
+Options:
+  --devices = List of comma separated device names (Optional)
+  --payload = JSON dictionary of key/values, serving as starting data for the service to be used later (Optional)
 
 Examples:
 
@@ -130,15 +151,33 @@ Examples:
  `flask run_service get_facts --payload '{"a": "b"}'`
  `flask run_service get_facts --devices Washington,Denver --payload '{"a": "b"}'`
 
-Delete old entries in the changelog
-***********************************
-This command will purge the changelog and retain only the latest information (default is 15 days).
+Delete old log entries
+**********************
+This command will purge logs changelog or result. By default, logs older than 15 days will be removed from their
+respective tables
 
-General syntax: ``flask delete-changelog --keep-last-days num_days_to_keep``
+General syntax:
+  ``flask delete_log --keep-last-days <value> --log <value>``
+
+Options:
+  --keep-last-days = Number of days to keep the logs (Optional: default to 15)
+  --log = The log information to remove the logs from, either "changelog" or "result" (Required)
 
 Examples:
 
 ::
 
-`flask delete-changelog --keep-last-days 10`
-`flask delete-changelog`    // will use the default and retain only the last 15 days of changelogs
+`flask delete_log --keep-last-days 10 --log result`    // will retain the last 10 days of result
+`flask delete_log --log changelog`                     // will retain the last 15 days of changelogs
+
+Refresh Network Configuration Data
+**********************************
+The Network Configuration data can be gathered and then stored in a central location, namely the git repository. eNMS
+can be used to fetch the Network Configuration from git and have it stored locally in ``/network_data/``
+
+General syntax:
+  ``flask pull_git``
+
+Options:
+  None
+

--- a/docs/advanced/configuration_management.rst
+++ b/docs/advanced/configuration_management.rst
@@ -2,41 +2,57 @@
 Configuration Management
 ========================
 
-eNMS can work as a network device configuration backup tool and replace Oxidized/Rancid with the following features:
-  - Poll network elements and store the latest configuration in the database
-  - Store any operational data that can be retrieved from the device CLI (``show version``, etc)
+eNMS can be used as a device configuration backup tool, like Oxidized/Rancid, with the following features:
+  - Poll network devices and store the latest configuration in the database
+  - Store any operational data that can be retrieved from the device CLI (e.g ``show version``, ``get facts`` etc.)
   - Search for any text or regular-expression in all configurations
   - Download device configuration to a local text file
   - Use the REST API support to return a specified device’s configuration
-  - Export all configurations to a remote Git repository (e.g. Gitlab) to view differences between various revisions of a configuration
+  - Export all configurations to a remote Git repository (e.g. Gitlab)
+  - View git-style differences between various revisions of a configuration
 
 Device configuration
 --------------------
 
-Configurations are retrieved by a service called ``Operational Data Backup``, which:
-  - Uses Netmiko to fetch the configuration and any operational data
+Configurations are retrieved by a service called "Operational Data Backup", which:
+  - Fetch the device configuration and any operational data using Netmiko
   - Updates the device ``Configuration`` and ``Operational Data`` properties
-  - Writes the configuration to a local text file (located in eNMS/network_data)
 
-For some devices, the configuration cannot be retrieved with only a netmiko command.
-You can create your own configuration backup service(s) if need be.
-Targets are defined at the service level, like any other services.
+For some devices, the configuration cannot be retrieved with only a netmiko command. In this case, you can either use the
+"Napalm Operational Data Backup" service to substitute a napalm getter, such as get_config, in place of retrieving the configuration
+via CLI command, or you can create your own configuration backup service(s) if required. Targets are defined at the service
+level, like any other services.
 
 Push configurations to git
 --------------------------
 
-
+Configurations are written to a local text file, located in ``/network_data/``, which is mapped in the ``settings.json``
+to a git repository.  Upon retrieving the current configuration from a device, the config is added to the database, as well
+to the local text file. Git is used for storing historical revisions of the data, and each additional instance of eNMS
+can retrieve the Git history of operational data using the ``Admin Button -> Fetch Git Configurations Button``. Git fetch
+can also be configured in the cron to periodically get triggered through the CLI to update the Configurations that were
+pushed into Git by another instance of eNMS.
 
 Search and display the configuration
 ------------------------------------
 
-From the :guilabel:`Inventory / Device Management`, you can search for a specific word
-in the current configuration of all devices with the ``Advanced Search`` mechanism,
-column ``Current Configuration``.
-eNMS will filter the list of devices based on whether the current configuration of the device
-contains this word.
-By clicking on the ``Configuration`` button, you can display the device configuration.
+From the :guilabel:`Inventory -> Configurations`, you can search for a specific word, a string that is included in a
+pattern or a regular expression in the current configuration of all devices, using the `Configuration` column. eNMS
+will filter the list of devices based on whether the current configuration of the device contains the search criteria.
+Select the "Lines of Context" slider at the top of the UI to see, up to 5 lines, before and after, the specified word
+that was searched.
 
-.. image:: /_static/advanced/configuration_management/display_configuration.png
-   :alt: Display Configuration.
+By clicking on the ``Network Data`` button on the right of the screen, you can display the device Configuration and the
+Operational Data
+
+.. image:: /_static/base/configuration_search.png
+   :alt: Configuration Search.
    :align: center
+
+By clicking on the ``Historic`` button on the right of the screen, you can view the differences between various
+revisions of the device configuration
+
+.. image:: /_static/base/configuration_history.png
+   :alt: Configuration Comparison.
+   :align: center
+

--- a/docs/advanced/rest_api.rst
+++ b/docs/advanced/rest_api.rst
@@ -5,43 +5,30 @@ REST API
 In this section, the word ``instance`` refers to any object type supported by eNMS. In a request,
 ``<instance_type>`` can be any of the following: ``device``, ``link``, ``user``, ``service``, ``task``, ``pool``.
 
-eNMS has a REST API allowing to:
+eNMS has a REST API that can:
 
 .. contents::
   :local:
   :depth: 1
 
-Ping eNMS
----------
+|
 
-Test that eNMS is alive.
-
-.. code-block:: python
-  :caption: GET Request
-
-  /rest/is_alive
-
-.. code-block:: python
-  :caption: Response
-
-  {
-      "name": 153558346480170,
-      "cluster_id": true,
-  }
+|
 
 Run a service
--------------
+#############
 
-Request
-*******
+Services can be run using a standard end point with a payload used to define service specifics.
 
 .. code-block:: python
   :caption: **POST** Request
 
   /rest/run_service
 
-Payload
-*******
+|
+
+Service Payload Criteria
+************************
 
 - ``name`` (**mandatory**) Name of the service.
 - ``devices`` (default: ``[]``) List of target devices. By default, the service will run on the devices configured from the web UI
@@ -53,10 +40,10 @@ Payload
   - ``false`` eNMS runs the service and responds to your request when the service is done running.
     The response will contain the result of the service, but the connection might time out
     if the service takes too much time to run.
-  - ``true`` eNMS runs the service in a different thread and immediately respond with the service ID.
+  - ``true`` eNMS runs the service in a different thread and immediately responds with the service ID.
 
 .. code-block:: python
-  :caption: Example
+  :caption: Service Payload Example
 
   {
     "name": "my_service_or_workflow",
@@ -69,27 +56,158 @@ Payload
 
 Note:
 
-- If you do not provide a value for ``devices`` you will get the defualut devices built into the web UI, even if you provide a value in ``pools`` or ``ip_address``.
+- If you do not provide a value for ``devices`` you will get the default devices built into the web UI, even if you
+  provide a value in ``pools`` or ``ip_address``.
 - For Postman use the type "raw" for entering key/value pairs into the body. Body must also be formatted as application/JSON.
-- Extra form data parameters passed in the body of the POST are available to that service or workflow in payload["rest_data"][your_key_name1] and payload["rest_data"][your_key_name2], and they can be accessed within a Service Instance UI form as {{payload["rest_data"][your_key_name].
+- Extra form data parameters passed in the body of the POST are available to that service or workflow in
+  payload["rest_data"][your_key_name1] and payload["rest_data"][your_key_name2], and they can be accessed within a Service
+  Instance UI form as {{payload["rest_data"][your_key_name].
 
-Device Search with Config RegEX Matching
--------------------------------------------
+Run Service Response - Synchronous
+**********************************
 
-Request
-*******
+If the "async" argument is either **false** or omitted, then the request will block
+until the service has been run to completion or manually stopped.
+
+This is subset of the JSON response returned for a device-by-device workflow.
+
+.. code-block:: python
+  :caption: Run Service Response Example - Synchronous
+
+  {
+    "runtime": "2020-04-28 12:21:11.404910",
+    "success": true,
+    "summary": {
+        "success": [
+            "Device1_Name",
+            "Device2_Name"
+        ],
+        "failure": []
+    },
+    "duration": "0:00:01",
+    "trigger": "REST",
+    "devices": {
+       ...
+    },
+    "errors": []
+  }
+
+Run Service Response - Asynchronous
+***********************************
+If the "async" argument is true, then you will get JSON response with the **runtime**
+name needed to retrieve the results.
+
+.. code-block:: python
+  :caption: Run Service Response Example - async
+
+   {
+      "errors": [],
+      "runtime": "2020-04-28 12:16:45.201077"
+   }
+
+
+Retrieve the results of a service
+#################################
+
+.. code-block:: python
+  :caption: GET Request
+
+  /rest/result/<service_name>/<runtime>
+  /rest/result/My%20Service/2020-04-29%2000:39:22.540921
+
+|
+
+- You will need to replace blank spaces ' ' in the service_name and runtime with '%20'
+- The **status** property in the result will show either "Running" or "Completed"
+
+.. code-block:: python
+  :caption: Get run service result - result not ready yet (200)
+
+  {
+      "status": "Running",
+      "result": "No results yet."
+  }
+
+|
+
+The response when the result is ready will look very close to the synchronous result, above - but nested one level deeper inside the "result" property, below.
+
+.. code-block:: python
+  :caption: Get run service result - result is ready (200)
+
+  {
+      "status": "Completed",
+      "result": {
+          "runtime": "2020-04-28 12:47:43.492570",
+          "success": true,
+          "summary": {
+              "success": [
+                  "Device1_Name",
+                  "Device2_Name"
+              ],
+              "failure": []
+          },
+          "duration": "0:00:02",
+  }
+
+
+|
+
+Retrieve or delete an instance
+##############################
+
+Retrieve all attributes for a given instance.
+
+.. code-block:: python
+  :caption: **GET** or **DELETE** Request
+
+
+  /rest/instance/<instance_type>/<instance_name>
+
+
+
+|
+
+Retrieve a list of instances with a simple query
+################################################
+
+Retrieve all instances that mach a simple query.
+
+::
+
+ # via a GET method to the following URL
+ https://<IP_address>/rest/query/<instance_type>?parameter1=value1&parameter2=value2...
+
+ Example: http://enms_url/rest/query/device
+ Returns all devices
+
+ Example: http://enms_url/rest/query/device?port=22&operating_system=eos
+ Returns all devices whose port is 22 and operating system EOS
+
+
+|
+
+Retreive a list of instances with customized query
+##################################################
+
+Custom table search that allows users to define desired columns to be returned. This search also allows user to define
+RegEx search to be used to find matching instances.
+
+
+Custom Query Request
+********************
 
 .. code-block:: python
   :caption: **POST** Request
 
   /rest/search
 
-Payload
-*******
+Custom Query Payload
+********************
 
 - ``type`` - Type of object to search (device, link, ...)
 - ``columns`` - List of attributes that will become keys in dictionary response
-- ``maximum_return_records`` - Interger indicating the maximum number of records to return
+- ``maximum_return_records`` - Integer indicating the maximum number of records to return
 - ``search_criteria`` - Dictionary requiring two key/value pairs to define a single search parameter
 
 .. code-block:: python
@@ -114,50 +232,33 @@ Payload
 
 Note:
 
-- Possible ``columns`` (or attributes) include: name, description, subtype, model, location, vendor, operating_system, os_version, ip_address, port, configuration, operational_data. Other custom_properties maybe available in your enviroment.
+- Possible ``columns`` (or attributes) include: name, description, subtype, model, location, vendor, operating_system,
+  os_version, ip_address, port, configuration, operational_data. Other custom_properties maybe available in your environment.
 - Special ``columns``  "matches" is derived from a RegEX match "configuration", which returns the line where a regex was found
 - The example above will search for configurations using the regex of "link-".
-- Note the use of configuration attribute is used twice to define a single parameter in ``search_criteria``. Additional pairs can be added to ``search_criteria`` to further refine the search.
-- Note in the above example that the attribute used to serach on is not required in ``search_criteria``.
+- Note the use of configuration attribute is used twice to define a single parameter in ``search_criteria``. Additional
+  pairs can be added to ``search_criteria`` to further refine the search.
+- Note in the above example that the attribute used to search on is not required in ``search_criteria``.
 - (attribute)_filter: options include "regex", "inclusion", "exclusion".
 
 
-Retrieve or delete an instance
-------------------------------
-
-.. code-block:: python
-  :caption: **GET** or **DELETE** Request
-
-  /rest/instance/<instance_type>/<instance_name>
-
-Retrieve a list of instances with a query
------------------------------------------
-
-You can retrieve in one query all instances that match a given set of parameters.
-
-::
-
- # via a GET method to the following URL
- https://<IP_address>/rest/query/<instance_type>?parameter1=value1&parameter2=value2...
-
- Example: http://enms_url/rest/query/device
- Returns all devices
-
- Example: http://enms_url/rest/query/device?port=22&operating_system=eos
- Returns all devices whose port is 22 and operating system EOS
-
-
+|
 
 Retrieve the configuration of a device
---------------------------------------
+######################################
+
+Returns the configuration for a device that has been previously retrieved from the network and stored in the application.
 
 .. code-block:: python
   :caption: GET Request
 
   /rest/configuration/<device_name>
 
+|
+
 Create or update an instance
-----------------------------
+############################
+Used to build or modify and instance in the application.
 
 ::
 
@@ -178,8 +279,10 @@ Example of payload to schedule a task from the REST API: this payload will creat
 
 This task schedules the service ``netmiko_check_vrf_test`` to run at ``20/06/2019 23:15:15`` on the device whose name is ``Baltimore``.
 
-Migrations
-**********
+|
+
+Migrate between eNMS applications
+###################################
 
 The migration system can be triggered from the REST API:
 
@@ -191,7 +294,8 @@ The migration system can be triggered from the REST API:
  # Import: via a POST method to the following URL
  https://<IP_address>/rest/migrate/import
 
-The body must contain the name of the project, the types of instance to import/export, and an boolean parameter called ``empty_database_before_import`` that tells eNMS whether or not to empty the database before importing.
+The body must contain the name of the project, the types of instance to import/export, and an boolean parameter called
+``empty_database_before_import`` that tells eNMS whether or not to empty the database before importing.
 
 Example of body:
 
@@ -235,8 +339,11 @@ The import and export of topology can be triggered from the REST API, with a POS
  # Import: via a POST method to the following URL
  https://<IP_address>/rest/topology/import
 
-For the import, you need to attach the file as part of the request (of type "form-data" and not JSON) and set the two following ``key`` / ``value`` pairs:
- - replace: Whether or not the existing topology must be erased and replaced by the newly imported objects.
+For the import, you need to attach the file as part of the request (of type "form-data" and not JSON). You must also set
+the two following ``key`` / ``value`` pairs.
+
+ replace: Whether or not the existing topology must be replaced by the newly imported objects
+
 
 Example of python script to import programmatically:
 
@@ -263,8 +370,31 @@ For the export, you must set the name of the exported file in the JSON payload:
      "name": "rest"
  }
 
-Administration panel functionality
-**********************************
+|
+
+Ping eNMS
+###########
+
+Test that eNMS is alive.
+
+.. code-block:: python
+  :caption: GET Request
+
+  /rest/is_alive
+
+.. code-block:: python
+  :caption: Response
+
+  {
+      "name": 153558346480170,
+      "cluster_id": true,
+  }
+
+
+|
+
+Administration functionality
+############################
 
 Some of the functionalities available in the administration panel can be accessed from the REST API as well:
 

--- a/docs/advanced/search_system.rst
+++ b/docs/advanced/search_system.rst
@@ -2,24 +2,36 @@
 Search System
 =============
 
-All objects stored in the database are displayed in tables that you can filter using a search mechanism.
+All objects stored in the database are displayed in tables that you can filter using the following options:
+
+.. contents::
+  :local:
+  :depth: 1
+
+|
+
+Quick search
+############
+For a quick search, you can use the textbox displayed above columns in the table as pictured by the white magnifying glass.
+In it's default state (Inclusion), this filter finds matches that include the text provided and is not case sensitive (i.e. a or A).
+The drop down to the right of the magnifying glass has options to change the filter to return on exact matches (Equality), which is also not case sensitive.
+And, the last quick filter option is based on a user provided Regular Expression.
+
 
 .. image:: /_static/advanced/search_system/filtering.png
    :alt: Filtering System.
    :align: center
 
-Quick Search
-------------
 
-For a quick search, you can use the textbox displayed above some of the columns in the table.
-This search is **case-insensitive** and based on **inclusion**.
 
-.. note:: If you enter ``a`` under ``Name``, eNMS will return all objects whose name contains ``a`` or ``A``.
 
-.. note:: If you use several of these fields, all fields must match (boolean ``AND``).
+.. note:: If you use several of these fields the results will be based on all fields where input was provided. (i.e. it uses a boolean ``AND``).
 
-Advanced Search
----------------
+|
+
+Advanced search
+###############
+Additional filter criteria that will allow you to specify relationships between objects based on the following.
 
 .. image:: /_static/advanced/search_system/advanced_filtering.png
    :alt: Advanced Filtering System.
@@ -41,7 +53,4 @@ Advanced Search
 - **Standard properties**: You can filter based on inclusion, equality or a regular expression.
 
 .. note:: The search based on regular expression only works if the database you are using supports it.
-  PostgreSQL and MySQL support regular expressions, but SQLite doesn't.
-
-Example
-*******
+  PostgreSQL and MySQL support regular expressions, but SQLite does not.

--- a/docs/automation/default_services.rst
+++ b/docs/automation/default_services.rst
@@ -2,98 +2,201 @@
 Default Services
 ================
 
-Parameters common to the services that use netmiko
---------------------------------------------------
-
-- ``Privileged mode`` If checked, Netmiko should enter enable mode on the device before applying the above configuration block 
-- ``Driver`` Which Netmiko driver to use when connecting to the device
-- ``Use driver from device`` If set to True, the driver defined at device level (``netmiko_driver`` property of the device) is used, otherwise the driver defined at service level (``driver`` property of the service) is used. By default, this property is set to ```True`` and eNMS uses the driver defined in the ``netmiko_driver`` property of the device. A **driver** can be selected among all available netmiko drivers. The list of drivers is built upon netmiko ``CLASS_MAPPER_BASE`` in ``ssh_dispatcher.py`` (https://github.com/ktbyers/netmiko/blob/develop/netmiko/ssh_dispatcher.py#L69.
-- ``Fast CLI`` If checked, Netmiko will disable internal wait states and delays in order to execute the service as fast as possible.
-- ``Timeout`` Netmiko internal timeout in seconds to wait for a connection or response before declaring failure.
-- ``Delay factor`` Netmiko multiplier used to increase internal delays (defaults to 1). Delay factor is used in the send_command Netmiko method. See here for more explanation: (https://pynet.twb-tech.com/blog/automation/netmiko-what-is-done.html)
-- ``Global delay factor`` Netmiko multiplier used to increase internal delays (defaults to 1). Global delay factor affects more delays beyond Netmiko send_command. Increase this for devices that have trouble buffering and responding quickly.
-- ``Strip command`` Remove the echo of the command from the output (default: True).
-- ``Strip prompt`` Remove the trailing router prompt from the output (default: True).
-- ``Auto Find Prompt``: Tries to detect the prompt automatically.
-
-Parameters common to the services that use Napalm
+Ansible Playbook Service
 -------------------------------------------------
 
-- ``Driver`` Which Napalm driver to use when connecting to the device
-- ``Use driver from device`` If set to True, the driver defined at device level (``napalm_driver`` property of the device) is used, otherwise the driver defined at service level (``driver`` property of the service) is used.
-- ``Optional arguments`` Napalm supports a number of optional arguments that are documented here: (https://napalm.readthedocs.io/en/latest/support/index.html#optional-arguments)
+An ``Ansible Playbook`` service sends an ansible playbook to the devices.
+The output can be validated with a command / pattern mechanism, like the ``Netmiko Validation Service``.
 
-Service Parameters
-------------------
+Configuration parameters for creating this service instance:
+
+- ``Playbook Path`` path and filename to the Ansible Playbook. The location for displaying playbooks is configurable in
+  eNMS settings.
+- ``Arguments`` ansible-playbook command line options, which are documented here: (https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html)
+- ``Pass device properties to the playbook`` Pass inventory properties using --extra-vars to the playbook if checked
+  (along with the options dictionary provided below). All device properties are passed such as ``device.name`` or ``device.ip_address``
+- ``options`` Additional --extra-vars to be passed to the playbook using the syntax {'key1':value1, 'key2': value2}.
+  All inventory properties are automatically passed to the playbook using --extra-vars (if pass_device_properties is
+  selected above). These options are appended.
+
+
+.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `arguments` and
+   `options` input fields of its configuration form.
+
+
+Netmiko Services
+--------------------------------------------------
+
+The Netmiko services provide the ability to perform multiple actions through an SSH connection. Below are the values
+common to each Netmiko service and the specifics for each are in their own sections.
+
+Common Netmiko Parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- ``Driver`` This selects which Netmiko driver to use when connecting to the device. This is not used if ``Use Device Driver``
+  is checked.
+- ``Use Device Driver`` If checked, the driver assigned to the device in the inventory will be used.
+- ``Enable mode`` If checked, Netmiko should enter enable\priviledged mode on the device before applying the above
+  configuration block. For the Linux driver, this means root/sudo.
+- ``Config mode`` If checked, Netmiko should enter config mode
+- ``Fast CLI`` If checked, Netmiko will disable internal wait states and delays in order to execute the service as fast as possible.
+- ``Timeout`` Netmiko internal timeout in seconds to wait for a connection or response before declaring failure.
+- ``Delay factor`` Netmiko multiplier used to increase internal delays (defaults to 1). Delay factor is used in the
+  send_command Netmiko method. See here for more explanation: (https://pynet.twb-tech.com/blog/automation/netmiko-what-is-done.html)
+- ``Global delay factor`` Netmiko multiplier used to increase internal delays (defaults to 1). Global delay factor affects
+  more delays beyond Netmiko send_command. Increase this for devices that have trouble buffering and responding quickly.
+
+Jump on connect Parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Jump on connect is designed to allow a second connection after connecting to the original device.
+
+- ``Jump to remote device on connect`` If checked, the config items below will be processed for connection to the
+  secondary device.
+- ``Command that jumps to device`` Command to initiate secondary connection
+- ``Expected username prompt`` Prompt expected when connecting secondary connection
+- ``Device username`` The username to send when the expected username prompt is detected
+- ``Expected password prompt`` Prompt expected when connecting secondary connection
+- ``Device password`` The password to send when the expected password prompt is detected
+- ``Expected prompt after login`` Prompt expected after successfully negotiating a connection
+- ``Command to exit device back to original device`` Command required to exit the secondary connection
+
 
 Netmiko Configuration Service
-*****************************
-
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Uses Netmiko to send a list of commands to be configured on the devices.
 
 Configuration parameters for creating this service instance:
 
-- All Netmiko parameters (see above)
-- ``Content`` Paste a configuration block of text here for applying to the target device(s).
-- ``Exit config mode`` Determines whether or not to exit config mode after complete.
-- ``Commit Configuration`` Calls netmiko ``commit`` function of the driver to commit the configuration.
+- All Common Netmiko Parameters (see above)
+- ``Content`` Paste a configuration block of text here for applying to the target device(s)
+- ``Commit Configuration`` Calls netmiko ``commit`` function of the driver to commit the configuration
+- ``Exit config mode`` Determines whether or not to exit config mode after complete
+- ``Config Mode Command`` The command that will be used to enter config mode
 
-.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `content` input field of its configuration form.
+- Advanced Netmiko Parameters
+- ``Strip command`` Remove the echo of the command from the output (default: True)
+- ``Strip prompt`` Remove the trailing router prompt from the output (default: True)
+
+.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `content` input
+   field of its configuration form.
 
 Netmiko File Transfer Service
-*****************************
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Uses Netmiko to send a file to a device, or retrieve a file from a device.
+Uses Netmiko to send a file to a device, or retrieve a file from a device. Only Cisco IOS and some Juniper devices are
+supported at this time for SCP file transfer.
 
 Configuration parameters for creating this service instance:
 
-- All Netmiko parameters (see above)
-- ``Destination file`` Destination file; absolute path and filename to send the file to
-- ``Direction`` Upload or Download from the perspective of running on the device
-- ``disable_md5`` Disable checksum validation following the transfer
-- ``File system`` Mounted filesystem for storage on the default. For example, disk1:
-- ``inline_transfer`` Cisco specific method of transferring files between internal components of the device
-- ``overwrite_file`` If checked, overwrite the file at the destination if it exists
+- All Common Netmiko Parameters (see above)
 - ``Source file`` Source absolute path and filename of the file to send
+- ``Destination file`` Destination file; absolute path and filename to send the file to
+- ``File system`` Mounted filesystem for storage on the default. For example, disk1:
+- ``Direction`` Upload or Download from the perspective of running on the device
+- ``Disable_md5`` Disable checksum validation following the transfer
+- ``Inline_transfer`` Cisco specific method of transferring files between internal components of the device
+- ``Overwrite_file`` If checked, overwrite the file at the destination if it exists
+
+Netmiko Operational Data Backup Service
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This service uses Netmiko to send commands to store information from devices.
+
+Configuration File Creation
+""""""""""""""""""""""""""""
+- All Common Netmiko Parameters (see above)
+- ``Command to retrieve the configuration`` This is the command to show the entire config.
+
+Create Operational Data File
+"""""""""""""""""""""""""""""
+- All Common Netmiko Parameters (see above)
+- ``Operational Data Command x`` - This is a series of twelve commands that are used to pull operational and status information.
+- ``Label`` This is the label the data will be given in the results
+
+Search Response and Replace
+"""""""""""""""""""""""""""""
+- Used in ``Config File Creation`` and ``Operational Data File`` to filter out unwanted information
+- ``Pattern`` The pattern to search through the retrieved data to replace
+- ``Replace With`` This is what will be substituted when the ``pattern`` is found.
 
 Netmiko Prompts Service
-***********************
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Similar to Netmiko Validation Service, but expects up to 3 interactive prompts for your remote command, such as 'Are you sure? Y/N'.
 This service allows the user to specify the expected prompt and response to send for it.
 
 Configuration parameters for creating this service instance:
 
-- All Netmiko parameters (see above)
-- All Validation parameters (see above)
+- All Common Netmiko Parameters (see above)
 - ``Command`` CLI command to send to the device
-- ``confirmation1`` first expected confirmation question prompted by the device
-- ``response1`` response to first confirmation question prompted by the device
-- ``confirmation2`` second expected confirmation question prompted by the device
-- ``response2`` response to second confirmation question prompted by the device
-- ``confirmation3`` third expected confirmation question prompted by the device
-- ``response3`` response to third confirmation question prompted by the device
+- ``Confirmation1`` first expected confirmation question prompted by the device
+- ``Response1`` response to first confirmation question prompted by the device
+- ``Confirmation2`` second expected confirmation question prompted by the device
+- ``Response2`` response to second confirmation question prompted by the device
+- ``Confirmation3`` third expected confirmation question prompted by the device
+- ``Response3`` response to third confirmation question prompted by the device
 
-.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `command` input field of its configuration form.
+.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `command` input
+   field of its configuration form.
 
 Netmiko Validation Service
-**************************
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Uses Netmiko to send commands to a device and validates the output to determine the state of that device. See the ``Workflow`` section for examples of how it is used in a workflow.
+Uses Netmiko to send commands to a device and validates the output to determine the state of that device. See the ``Workflow``
+section for examples of how it is used in a workflow.
 
-There is a ``command`` field and a ``pattern`` field. eNMS will check if the expected pattern can be found in the output of the command. The values for a ``pattern`` field can also be a regular expression.
+There is a ``command`` field and an ``expect string`` field in the Advanced Netmiko Parameters. eNMS will check if the
+expected pattern can be found in the output of the command. The values for a ``pattern`` field can also be a regular expression.
 
 Configuration parameters for creating this service instance:
 
-- All Netmiko parameters (see above)
+- All Common Netmiko Parameters (see above)
 - All Validation parameters (see above)
 - ``Command`` CLI command to send to the device
 
-.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `command` input field of its configuration form.
+Also included in Netmiko Advanced Parameters:
+- ``Expect String`` This is the string that signifies the end of output.
+- ``Auto Find Prompt`` Tries to detect the prompt automatically.
+
+.. note:: ``Expect String`` and ``Auto Find Prompt`` are mutually exclusive; both cannot be enabled at the same time.
+   If the user does not expect Netmiko to find the prompt automatically, the user should provide the expected prompt instead.
+
+- ``Strip command`` Remove the echo of the command from the output (default: True).
+- ``Strip prompt`` Remove the trailing router prompt from the output (default: True).
+- ``Use Genie`` Use Cisco's Genie implementation to create structured data from cli commands. (Currently does not work
+  with some vendors. Refer to this link to see which CLI commands are currently supported: https://developer.cisco.com/docs/genie-docs/)
+
+.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `command` input
+   field of its configuration form.
+
+Napalm Services
+-------------------------------------------------
+
+Napalm connections are SSH connections to equipment in which a pre-defined set of data is retrieved from the equipment
+and presented to the user in a structured (dictionary) format.
+
+
+Napalm Common Parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- ``Driver`` Which Napalm driver to use when connecting to the device
+- ``Use driver from device`` If set to True, the driver defined at device level (``napalm_driver`` property of the device)
+  is used, otherwise the driver defined at service level (``driver`` property of the service) is used.
+- ``Optional arguments`` Napalm supports a number of optional arguments that are documented here:
+  (https://napalm.readthedocs.io/en/latest/support/index.html#optional-arguments)
+
+Napalm Operational Data Backup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This service uses Napalm to pull configuration and operational data from devices to store the data for later comparison
+and for historical tracking.
+
+- All Napalm Common Parameters (See Above)
+- ``Configuration Getters`` - Choose the configuration getter named 'Configuration'
+
 
 Napalm Configuration service
-****************************
-
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Uses Napalm to configure a device.
 
 Configuration parameters for creating this service instance:
@@ -104,10 +207,47 @@ Configuration parameters for creating this service instance:
     - ``Load replace``: replace the configuration of the target with the service configuration
 - ``Content`` Paste a configuration block of text here for applying to the target device(s)
 
-.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `content` input field of its configuration form.
+.. note:: This service is supported by a limited set of products.
+.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `content` input field
+   of its configuration form.
+
+Napalm Getters service
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Uses Napalm to retrieve a list of getters whose output is displayed in the logs. The output can be validated with a
+command / pattern mechanism like the ``Netmiko Validation Service``.
+
+Configuration parameters for creating this service instance:
+
+- All Validation parameters (see above)
+- All Napalm parameters (see above)
+- ``Getters`` Choose one or more getters to retrieve; Napalm getters (standard retrieval APIs) are documented here:
+  (https://napalm.readthedocs.io/en/latest/support/index.html#getters-support-matrix)
+
+
+.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `content_match` input field of its configuration form.
+
+Napalm Ping service
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Uses Napalm to connect to the selected target devices and performs a ping to a designated target. The output contains
+ping round trip time statistics. Note that the iosxr driver does not support ping, but you can use the ios driver in its
+place by not selecting ``Use_device_driver``.
+
+Configuration parameters for creating this service instance:
+
+- All Napalm parameters (see above)
+- ``Count``: Number of ping packets to send
+- ``Size`` Size of the ping packet payload to send in bytes
+- ``Source IP address`` Override the source ip address of the ping packet with this provided IP
+- ``Timeout`` Seconds to wait before declaring timeout
+- ``Ttl`` Time to Live parameter, which tells routers when to discard this packet because it has been in the network too
+  long (too many hops)
+- ``Vrf`` Ping a specific virtual routing and forwarding interface
+
 
 Napalm Rollback Service
-***********************
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Use Napalm to rollback a configuration.
 
@@ -115,37 +255,8 @@ Configuration parameters for creating this service instance:
 
 - All Napalm parameters (see above)
 
-Napalm Getters service
-**********************
-
-Uses Napalm to retrieve a list of getters whose output is displayed in the logs. The output can be validated with a command / pattern mechanism like the ``Netmiko Validation Service``.
-
-Configuration parameters for creating this service instance:
-
-- All Validation parameters (see above)
-- All Napalm parameters (see above)
-- ``Getters`` Napalm getters (standard retrieval APIs) are documented here: (https://napalm.readthedocs.io/en/latest/support/index.html#getters-support-matrix)
-
-.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `content_match` input field of its configuration form.
-
-Napalm Ping service
-*******************
-
-Uses Napalm to connect to the selected target devices and performs a ping to a designated target. The output contains ping round trip time statistics.
-Note that the iosxr driver does not support ping, but you can use the ios driver in its place by not selecting ``use_device_driver``.
-
-Configuration parameters for creating this service instance:
-
-- All Napalm parameters (see above)
-- ``count``: Number of ping packets to send
-- ``size`` Size of the ping packet payload to send in bytes
-- ``Source IP address`` Override the source ip address of the ping packet with this provided IP
-- ``Timeout`` Seconds to wait before declaring timeout
-- ``ttl`` Time to Live parameter, which tells routers when to discard this packet because it has been in the network too long (too many hops)
-- ``vrf`` Ping a specific virtual routing and forwarding interface
-
 Napalm Traceroute service
-*************************
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Uses Napalm to connect to the selected target devices and performs a traceroute to a designated target.
 
@@ -154,49 +265,35 @@ Configuration parameters for creating this service instance:
 - All Napalm parameters (see above)
 - ``Source IP address`` Override the source ip address of the ping packet with this provided IP
 - ``Timeout`` Seconds to wait before declaring timeout
-- ``ttl`` Time to Live parameter, which tells routers when to discard this packet because it has been in the network too long (too many hops)
+- ``ttl`` Time to Live parameter, which tells routers when to discard this packet because it has been in the network too
+  long (too many hops)
 - ``vrf`` Ping a specific virtual routing and forwarding interface
 
-Ansible Playbook Service
-************************
-
-An ``Ansible Playbook`` service sends an ansible playbook to the devices.
-The output can be validated with a command / pattern mechanism, like the ``Netmiko Validation Service``.
-An option allows inventory devices to be selected, such that the Ansible Playbook is run on each device in the selection. Another option allows device properties from the inventory to be passed to the ansible playbook as a dictionary.
-
-Configuration parameters for creating this service instance:
-
-- All Validation parameters (see above)
-- ``playbook_path`` path and filename to the Ansible Playbook. For example, if the playbooks subdirectory is located inside the eNMS project directory:  playbooks/juniper_get_facts.yml
-- ``arguments`` ansible-playbook command line options, which are documented here: (https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html)
-- ``options`` Additional --extra-vars to be passed to the playbook using the syntax {'key1':value1, 'key2': value2}.  All inventory properties are automatically passed to the playbook using --extra-vars (if pass_device_properties is selected below). These options are appended.
-- ``Pass device properties to the playbook`` Pass inventory properties using --extra-vars to the playbook if checked (along with the options dictionary provided above).
-
-.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `playbook_path` and `content_match` input fields of its configuration form.
-
 REST Call Service
-*****************
+-------------------------------------------------
 
 Send a REST call (GET, POST, PUT or DELETE) to a URL with optional payload.
 The output can be validated with a command / pattern mechanism, like the ``Netmiko Validation Service``.
 
 Configuration parameters for creating this service instance:
 
-- All Validation parameters (see above)
-- ``Type of call`` REST type operation to be performed: GET, POST, PUT, DELETE
-- ``URL`` URL to make the REST connection to
+- ``Call Type`` REST type operation to be performed: GET, POST, PUT, DELETE
+- ``Rest Url`` URL to make the REST connection to
 - ``Payload`` The data to be sent in POST Or PUT operation
-- ``Parameters`` Additional parameters to pass in the request. From the requests library, params can be a dictionary, list of tuples or bytes that are sent in the body of the request.
-- ``Headers`` Dictionary of HTTP Header information to send with the request, such as the type of data to be passed. For example, {"accept":"application/json","content-type":"application/json"}
-- ``Verify SSL Certificate`` If checked (default), the SSL certificate is verified.
-- ``Timeout`` Requests library timeout, which is the Float value in seconds to wait for the server to send data before giving up
+- ``Params`` Additional parameters to pass in the request. From the requests library, params can be a dictionary, list
+  of tuples or bytes that are sent in the body of the request.
+- ``Headers`` Dictionary of HTTP Header information to send with the request, such as the type of data to be passed. For
+  example, {"accept":"application/json","content-type":"application/json"}
+- ``Verify SSL Certificate`` If checked, the SSL certificate is verified. Default is to not verify the SSL certificate.
+- ``Timeout`` Requests library timeout, which is the number of seconds to wait on a response before giving up
 - ``Username`` Username to use for authenticating with the REST server
 - ``Password`` Password to use for authenticating with the REST server
 
-.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `url` and `content_match` input fields of its configuration form.
+.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `url` and `content_match`
+   input fields of its configuration form.
 
 Generic File Transfer Service
-*****************************
+-------------------------------------------------
 
 Transfer a single file to/from the eNMS server to the device using either SFTP or SCP.
 
@@ -204,42 +301,82 @@ Configuration parameters for creating this service instance:
 
 - ``Direction`` Get or Put the file from/to the target device's filesystem
 - ``Protocol`` Use SCP or SFTP to perform the transfer
-- ``Source file`` For Get, source file is the path-plus-filename on the device to retrieve to the eNMS server. For Put, source file is the path-plus-filename on the eNMS server to send to the device.
-- ``Destination file`` For Get, destination file is the path-plus-filename on the eNMS server to store the file to. For Put, destination file is the path-plus-filename on the device to store the file to.
+- ``Source file`` For Get, source file is the path-plus-filename on the device to retrieve to the eNMS server. For Put,
+  source file is the path-plus-filename on the eNMS server to send to the device.
+- ``Destination file`` For Get, destination file is the path-plus-filename on the eNMS server to store the file to. For
+  Put, destination file is the path-plus-filename on the device to store the file to.
 - ``Missing Host Key Policy`` If checked, auto-add the host key policy on the ssh connection
-- ``Load known host keys`` If checked, load host keys on the eNMS server before attempting the connection
-- ``Look for keys`` Flag that is passed to the paramiko ssh connection to indicate if the library should look for host keys or ignore.
-- ``Source file includes glob pattern (Put Direction only)`` Flag indicates that for Put Direction transfers only, the above Source file field contains a Glob pattern match (https://en.wikipedia.org/wiki/Glob_(programming)) for selecting multiple files for transport. When Globing is used, the Destination file directory should only contain a destination directory, because the source file names will be re-used at the destination.
+- ``Load Known Host Keys`` If checked, load host keys on the eNMS server before attempting the connection
+- ``Look For Keys`` Flag that is passed to the paramiko ssh connection to indicate if the library should look for host keys or ignore.
+- ``Source file includes glob pattern (Put Direction only)`` Flag indicates that for Put Direction transfers only, the
+  above Source file field contains a Glob pattern match (https://en.wikipedia.org/wiki/Glob_(programming)) for selecting
+  multiple files for transport. When Globing is used, the Destination file directory should only contain a destination
+  directory, because the source file names will be re-used at the destination.
+- ``Max Transfer Size`` This is that maximum packet size that will be used during transfer. This may adversely impact transfer times.
+- ``Window Size`` This is the requested windows size during transfer. This may adversely impact transfer times.
 
-.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `url` and `content_match` input fields of its configuration form.
+.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `url` and `content_match`
+   input fields of its configuration form.
 
-Ping Service
-************
+ICMP\TCP Ping
+-------------------------------------------------
 
 Implements a Ping from this automation server to the selected devices from inventory using either ICMP or TCP.
 
 Configuration parameters for creating this service instance:
 
 - ``Protocol``: Use either ICMP or TCP packets to ping the devices
-- ``Ports`` Which ports to ping (should be formatted as a list of ports separated by a comma, for example "22,23,49").
-- ``count``: Number of ping packets to send
+- ``Ports (TCP ping only)`` Which ports to ping (should be formatted as a list of ports separated by a comma, for example "22,23,49").
+- ``Count``: Number of ping packets to send
 - ``Timeout`` Seconds to wait before declaring timeout
-- ``ttl`` Time to Live parameter, which tells routers when to discard this packet because it has been in the network too long (too many hops)
-- ``packet_size`` Size of the ping packet payload to send in bytes
+- ``Ttl`` Time to Live parameter, which tells routers when to discard this packet because it has been in the network too long (too many hops)
+- ``Packet Size`` Size of the ping packet payload to send in bytes
 
 UNIX Command Service
-********************
+-------------------------------------------------
 
 Runs a UNIX command **on the server where eNMS is installed**.
 
 Configuration parameters for creating this service instance:
 - ``Command``: UNIX command to run on the server
-- Validation Parameters
 
-.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `url` and `content_match` input fields of its configuration form.
+.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `url` and `content_match`
+   input fields of its configuration form.
+
+UNIX Shell Service
+-------------------------------------------------
+
+Runs a BASH script on the server where eNMS is installed.
+- ``Source Code`` Bash code to be run on the server.
+
+Mail Notification Service
+-------------------------------------------------
+
+This service is used to send an automatically generated email to a list of recipients.
+
+- ``Title`` Subject Line of the Email
+- ``Sender`` If left blank, the email address set in the ``settings.json`` will be used.
+- ``Recipients`` A comma delimited list of recipients for the email
+- ``Reply-to Address`` If left blank, the reply-to address from ``settings.json`` is used. If populated, this email will
+  be used by anyone replying to the automated email notification.
+- ``Body`` This is the body of the email.
+
+.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `url` and `content_match`
+   input fields of its configuration form.
+
+Mattermost Notification Service
+-------------------------------------------------
+
+This service will send a message to a mattermost server that is configured in the site settings.
+
+- ``Channel`` The channel the message will be posted to
+- ``Body`` The body of the message that will be posted to the above channel
+
+.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `url` and `content_match`
+   input fields of its configuration form.
 
 Python Snippet Service
-**********************
+-------------------------------------------------
 
 Runs any python code.
 
@@ -254,22 +391,67 @@ Configuration parameters for creating this service instance:
 - ``Source code``: source code of the python script to run.
 
 Payload Extraction Service
-**************************
+-------------------------------------------------
 
 Extract some data from the payload with a python query, and optionally post-process the result with a regular expression or a TextFSM template.
 
 Configuration parameters for creating this service instance:
-- ``Variable1``: name of the resulting variable in the results.
-- ``Python Query1``: a python query to retrieve data from the payload.
-- ``Match Type1``: choose the type of post-processing: no post-processing, regular expression, or TextFSM template.
-- ``Match``: regular expression or TextFSM template, depending on the value of the "Match Type1".
+- ``Variable Name``: name of the resulting variable in the results.
+- ``Python Extraction Query``: a python query to retrieve data from the payload.
+- ``Post Processing``: choose the type of post-processing: Use Value as Extracted, Apply Regular Expression(findall), or TextFSM template.
+- ``Regular Expression/ TestFSM Template Text``: regular expression or TextFSM template, depending on the value of the "Match Type1".
+- ``Operation`` Choose the operation type: Set/Replace, Append to a list, Extend List, Update dictionary
 - Same fields replicated twice (2,3 instead of 1): the service can extract / post-process up to 3 variables.
 
 Payload Validation Service
-**************************
+-------------------------------------------------
 
-Extract some data from the payload, and validate it against a string or a dictionary.
+Extract some data from the payload, and validate it against a string or a dictionary.  This is used for conducting extra
+validations of a prior service's result later in a workflow.
 
 Configuration parameters for creating this service instance:
-- All Validation parameters (see above)
+
 - ``Python Query``: a python query to retrieve data from the payload.
+
+Slack Notification Service
+-------------------------------------------------
+
+This service will send a message to the slack server that is configured in the site settings.
+
+- ``Channel`` The channel the message will be posted to
+- ``Token`` API Token to allow communications to the workspace
+- ``Body`` The body of the message that will be posted to the above channel
+
+.. note:: This Service supports variable substitution (as mentioned in the previous section) in the `url` and `content_match` input fields of its configuration form.
+
+Topology Import Service
+-------------------------------------------------
+
+Import the topology from an instance of LibreNMS, Netbox or OpenNMS.
+
+- ``Import Type`` Choose LibreNMS, Netbox or OpenNMS
+
+Netbox
+^^^^^^^^^^^
+
+Configuration settings and options for importing topology from a Netbox Server
+
+- ``Netbox Address`` Address for the netbox server
+- ``Netbox Token`` API token to allow netbox interactions
+
+OpenNMS
+^^^^^^^^^^^^^
+
+Options available for importing a known set of devices from OpenNMS
+
+- ``Opennms Adress`` Address for the OpenNMS server
+- ``Opennms Devices`` A list of devices to query in the OpenNMS server
+- ``Opennms Login`` Login for the OpenNMS Server
+- ``Opennms Password`` Password for the OpenNMS Server
+
+LibreNMS
+^^^^^^^^^^^^^^^^^^^
+
+Configuration settings and options for importing topology from LibreNMS
+- ``Librenms Address`` Address for the LibreNMS Server
+- ``Librenms Token`` API token for allowing interaction with LibreNMS.

--- a/docs/automation/scheduling.rst
+++ b/docs/automation/scheduling.rst
@@ -5,22 +5,61 @@ Scheduling
 Tasks
 -----
 
+Creating Tasks
+==============
+
 Instead of running services immediately, they can be scheduled by creating a task, from :guilabel:`Scheduling / Tasks`.
 You need to enter a name, which service you want the task to execute, and a scheduling mode.
+
 There are two scheduling modes:
-  - Date Scheduling: enter a start date and optionally a frequency and an end date.
+
+  - **Date Scheduling**: enter a start date and optionally a frequency and an end date.
     If a ``Frequency`` is defined without an end date, the service will keep running until manually stopped.
-  - Cron Scheduling: enter a crontab expression.
+  - **Cron Scheduling**: enter a crontab expression
+    - `Crontab format reference <https://en.wikipedia.org/wiki/Cron#Overview>`_
+    - reminder::
 
-Tasks can be paused and resumed. Active tasks display the date that they will next be run by the scheduler,
-as well as the amount of time left until then. Newly created tasks are set to pause by default.
+      minute(0-59) hour(0-23) day-of-month(1-31) month(1-12) day-of-week(0-6)
 
+  - Example - every 15 minutes on Tuesday and Thursday::
+
+       */15 * * * 2,4
 
 When creating a task, you can select a list of devices and pools. If these fields are left empty, the service will run on
-its own targets.
-Otherwise, the task targets (all selected devices, plus all devices of all selected pools) will override the service
+its own targets. Otherwise, the task targets (all selected devices, plus all devices of all selected pools) will override the service
 targets when the service runs.
+
 A task can also have a payload (dictionary) that will be passed to the service when it runs.
+
+Managing Tasks
+==============
+
+Newly created tasks are set to **paused** by default.  Tasks can be paused and resumed. Active tasks display the date that they will next be run by the scheduler,
+as well as the amount of time left until then.
+
+**Troubleshooting**: if a task is **Active** without a next run date, it is likely that
+the scheduled job database was lost.   Try editing the Task and saving it.  This will restore the scheduled
+portion of the Task.
+
+
+Timezone Considerations
+=======================
+
+When specifying a start time, you must take into account the server's time zone configuration.  Normally, this is in UTC
+(Coordinated Universal Time).   To run a scheduled task at a specific local time, the start time OR crontab expression will
+need to be adjusted depending on the local time zone - and Daylight Savings Time if applicable:
+
+  - Time zone conversion - CST/CDT
+
+      - Central Time zone (CST) is UTC-6 (Fall back)
+      - Central Daylight Time (CDT) is UTC-5  (Spring forward)
+
+  - Example
+
+      - Reporting service: every 8:00 AM on Monday/Wednesday/Friday
+      - Crontab - hour value is either **13:00 or 14:00** depending on the time of the year! ::
+
+         0 13 * * 1,3,5
 
 Syslog-triggered automation
 ---------------------------
@@ -30,7 +69,8 @@ matches a particular pattern.
 
 From :guilabel:`Scheduling / Events`, you can create these pattern-matching rules.
 
-A rule is defined by the following properties,
+A rule is defined by the following properties:
+
   - Name
   - Source IP: the IP address of the source.
   - Content: the content of the log.

--- a/docs/automation/services.rst
+++ b/docs/automation/services.rst
@@ -2,13 +2,18 @@
 Services
 ========
 
-A service is a Python script that performs an action. A service is defined by:
+Services provide the smallest unit of automation in eNMS.  Each service type provides unique functionality that is
+easily configured to perform complex operations in the network.  Examples: remote command execution, ReST API calls,
+Ansible playbook execution, and many more.
 
-- A **model** class: the service parameters, and what the service is doing via a ``job`` function.
-- A **form** class: the different fields eNMS displays in the UI, and their corresponding validation.
+Services can be powerful on their own, (e.g. ping all devices in the network and send a status email).
+They can also be combined within workflows to automate complex operations such as device upgrades.
+
+Each service type provides a form for configuring its unique functionality.  Common forms are available on every service
+for defining device targets, iteration, retries, pre and post processing, result validation, notifications, etc.
 
 eNMS comes with a number of "default" services based on network automation frameworks such as
-``netmiko``, ``napalm`` and ``ansible``, but you are free to create your own services.
+``netmiko``, ``napalm`` and ``ansible``, but you are free to create your own custom service types.
 Each service must return a python dictionary as a result.
 
 All services are displayed in :guilabel:`Automation / Services`, where you can create new services and
@@ -17,6 +22,12 @@ edit, duplicate, delete, and run existing ones.
 .. image:: /_static/automation/services/services.png
    :alt: Service Management page
    :align: center
+
+A service type is a Python script that performs an action. A service type is defined by:
+
+- A **model** class: the service parameters, and what the service is doing via a ``job`` function.
+- A **form** class: the different fields eNMS displays in the UI, and their corresponding validation.
+
 
 .. note::
 
@@ -33,17 +44,30 @@ Section ``General``
 Main Parameters
 """""""""""""""
 
-- ``Name`` (**mandatory**) Must be unique.
+- ``Scoped Name`` (**mandatory**) Must be unique either within the enclosing workflow or unique among top-level services.
+- ``Name`` (**display only**) Fully qualified service name including all workflow nesting and a **[Shared]** tag.
+- ``Service Type`` (**display only**) The service type of the current service instance.
+- ``Shared`` Checked for **Shared** services.  Once set, this value cannot be changed.
+
+.. note:: Services can be standalone, shared, or scoped within a workflow. Shared services (or subworkflows) can exist
+  inside multiple workflows, and a change to a shared service affects all workflows that use it. A service which is scoped
+  within a workflow, either by creating the service inside the workflow or by deep copying the service into the workflow,
+  exists only inside that workflow, so changes to it only affect its parent workflow.  A standalone service exists outside
+  of any workflow.
+
+- ``Workflows`` (**display only**) Displays the list of workflows that reference the service.
 - ``Description`` / ``Vendor`` / ``Operating System`` Useful for filtering services in the table.
+- ``Initial Payload`` User-defined dictionary that can be used anywhere in the service.
+
+.. note:: The retry will affect only the devices for which the service failed. Let's consider a service configured to run on 3 devices D1, D2, and D3 with 2 "retries". If it fails on D2 and D3 when the service runs for the first time, eNMS will run the service again for D2 and D3 at the first retry. If D2 succeeds and D3 fails, the second and last retry will run on D3 only.
+
 - ``Number of retries`` (default: ``0``) Number of retry attempts when the service fails (if the service has device targets, this
   is the number of retries for each device).
 - ``Time between retries (in seconds)`` (default: ``10``) Number of seconds to wait between each attempt.
-- ``Initial Payload`` User-defined dictionary that can be used anywhere in the service.
-
-.. note:: The retry will affect only the devices for which the service failed. Let's consider a service configured
-to run on 3 devices D1, D2, and D3 with 2 "retries". If it fails on D2 and D3 when the service runs for the first time,
-eNMS will run the service again for D2 and D3 at the first retry. If D2 succeeds and D3 fails, the second and last
-retry will run on D3 only.
+- ``Maximum number of retries (loop prevention mechanism)`` (default: ``100``) Used to prevent infinite loops in workflows
+  with circular paths.
+- ``Logging`` (default: ``Info``) The log level to use when running the service; it governs logs written to the log window
+  in the UI, as well as the logs that are written to the log files.
 
 Workflow Parameters
 """""""""""""""""""
@@ -52,13 +76,19 @@ This section contains the parameters that apply **when the service runs inside a
 
 - ``Preprocessing`` Section where you can write a python script that will run before the service is executed. If the service has
   device targets, the code will be executed for each device independently, and a ``device`` global variable is available.
+  Note: Preprocessing is executed for standalone services and those within a workflow.
 - ``Skip`` If ticked, the service is skipped.
-- ``Skip Query`` This fields expect a python code that will evaluates to either ``True``
+- ``Skip Query`` This fields expect a python expression that evaluates to either ``True``
   or ``False``. The service will be skipped if ``True`` and will run otherwise.
 - ``Skip Value`` Defines the success value of the service when skipped (in a workflow, the success value will define whether to follow the
   success path (success edge) or the failure path (failure edge).
-- ``Maximum number of runs`` (default: ``1``) Number of time a service is allowed to run in a workflow (de
-- ``Waiting time (in seconds)`` (default: ``0``) Number of seconds to wait after the service is done running.
+- ``Maximum number of runs`` (default: ``1``) Number of times a service is allowed to run in a workflow
+- ``Time to Wait before next service is started (in seconds)`` (default: ``0``) Number of seconds to wait after the service is done running.
+
+Custom Properties
+"""""""""""""""""
+The Custom Properties section allows each instance of eNMS to add extra properties to the service form.  Additional
+information for these fields may be available using the help icon next to the field label.
 
 Section ``Specific``
 ********************
@@ -66,6 +96,7 @@ Section ``Specific``
 This section contains all parameters that are specific to the service type. For instance, the "Netmiko Configuration"
 service that uses Netmiko to push a configuration will display Netmiko parameters (delay factor,
 timeout, etc) and a field to enter the configuration that you want to push.
+
 The content of this section is described for each service in the ``Default Services`` section of the docs.
 
 Section ``Targets``
@@ -75,51 +106,107 @@ Devices
 """""""
 
 Most services are designed to run on devices from the inventory. There are three properties for selecting devices.
-The list of targets will be the union of all devices coming from these properties.
+The full list of targets is the union of all devices coming from these properties.
 
 - ``Run Method`` Defines whether the service should run once, or if it should run once per device. Most default services are designed
   to run once per device.
 - ``Devices`` Direct selection by device names
-- ``Pools`` Direct selection from pools. The set of all devices from all selected pools will be used.
+- ``Pools`` and ``Update pools before running``
+
+  - ``Pools`` Direct selection from pools. The set of all devices from all selected pools is used.
+  - ``Update pools before running`` When selected, the pools are updated before reading their set of devices.
+
 - ``Device query`` and ``Query Property Type`` Programmatic selection with a python query
 
   - ``Device query`` Query that must return an **iterable** (e.g python list) of **strings (either IP addresses or names)**.
-  - ``Query Property Type`` Indicates whether the iterable contains IP addresses of names, for eNMS to convert the list
-    to actual devices from the inventory.
+  - ``Query Property Type`` Indicates whether the iterable contains IP addresses or names, for eNMS to look up actual devices from the inventory.
 
 - ``Multiprocessing`` Run on devices **in parallel** instead of **sequentially**.
-- ``Maximum Number of Processes`` (default: ``15``)
+  - Only standalone services and services run in a workflow using a service by service run method benefit from this option.
+  - Services in a workflow with run method **Run the workflow device by device** only have a single device.  Instead, use multiprocessing on the workflow.
+- ``Maximum Number of Processes`` (default: ``15``) The maximum number of concurrent threads for this service when multiprocessing is enabled.
 
 Iteration
 """""""""
 
-Validation
-**********
+Multiple actions are sometimes necessary when the service is triggered for a target device.  Use iteration devices when
+those actions should be performed on a set of devices related to the current target device.  Use iteration values when
+the actions should be performed on the current target device.
 
-The validation can consist in:
+- ``Iteration Devices`` Query that returns an **iterable** (e.g. Python list) of **strings (either IP addresses or names)**.
+
+  - The service is run for each device as the target device, allowing operations against a set of devices related to the original target.
+  - ``Iteration Devices Property`` Indicates whether iterable ``Iteration Devices`` contains IP addresses or names, for eNMS to look up actual devices from the inventory.
+
+- ``Iteration Values`` Query that returns an **iterable** (e.g. Python list) of **strings**.
+
+  - The service is run for each value.
+  - ``Iteration Variable Name`` Python variable name to contain each successive value from the ``Iteration Values`` query.
+
+
+Section ``Result``
+*******************
+
+The ``Result`` section defines operations on the service result.  Each form group offers a different type of results
+operation.  These operations are performed in the order found on the ``Result`` page.  Result operations are executed
+for each device for ``Run method`` **Run the service once for each device**, and are executed only once for
+``Run method`` **Run the service once**.
+
+
+Python Postprocessing
+"""""""""""""""""""""
+
+Python can be used to inspect or modify the service result.  This is typically used to perform complex validation or to
+extract values from the result for use in subsequent services.
+
+- ``Postprocessing Mode`` Control whether or not the ``Postprocessing`` script is executed
+
+  - ``Always run`` (**default**) The ``Postprocessing`` script will execute for each device
+  - ``Run on success only``
+  - ``Run on failure only``
+
+- ``PostProcessing`` A python script to inspect or update the current result.
+
+  - Variable **results**
+
+    - Contains the full results dictionary for the current device, exactly as seen in the results view.
+
+      - Changes to this dictionary are reflected in the final result of the service.
+
+    - **results["success"]** The overall service status.
+    - **results["result"]** The resulting data from running the service.
+
+  - See `Using python code in the service panel`_ for the full list of variables and functions.
+
+
+Validation
+""""""""""
+
+Validation can consist of:
   - Text matching: looking for a string in the result, or matching the result against a regular expression.
   - Dictionary matching: check that a dictionary is included or equal to the result.
   - Anything else: you can use python code to change the result, including the value of the ``success`` key.
 
-- ``Conversion Method`` (default: ``No conversion``) Some services will fetch a result from an external source.
-  There are three conversion modes:
+- ``Conversion Method`` The type of automatic conversion to perform on the service result.
 
+  - ``No conversion`` (default) Use the result with no modification.
   - ``Text`` Convert the result to a python string.
   - ``JSON`` Convert a string representing JSON data to a python dictionary.
   - ``XML`` Convert a string representing XML data to a python dictionary.
 
 - ``Validation Method`` The validation method depends on whether the result is a string or a dictionary.
 
-  - ``Text match`` Matches the result against ``Content Match`` (string inclusion, or regular expression if 
+  - ``No validation`` No validation is performed
+  - ``Text match`` Matches the result against ``Content Match`` (string inclusion, or regular expression if
     ``Match content against Regular expression`` is selected)
   - ``dictionary Equality`` Check for equality against the dictionary provided in ``Dictionary Match``
-  - ``dictionary Inclusion`` Check for dictionary inclusion, in the sense that all ``key`` : ``value``
-    pairs from the dictionary provided in ``Dictionary Match`` can be found in the result.
+  - ``dictionary Inclusion`` Check that all ``key`` : ``value`` pairs from the dictionary provided in ``Dictionary Match``
+    can be found in the result.
 
 - ``Negative Logic`` Reverses the ``success`` boolean value in the results: the result is inverted: a success
   becomes a failure and vice-versa. This prevents the user from using negative look-ahead regular expressions.
-- ``Delete spaces before matching`` (``Text`` match only) The output is stripped from all spaces and newlines.
-  in the result and ``Content Match`` (they can cause the match to fail)
+- ``Delete spaces before matching`` (``Text`` match only) All whitespace is stripped from both the output and
+  ``Content Match`` before comparison to prevent these differences from causing the match to fail.
 
 Notification
 ************
@@ -150,6 +237,7 @@ list of all passed and failed objects.
 
 In Mattermost, if the ``Mattermost Channel`` is not set, the default ``Town Square`` will be used.
 
+
 Using python code in the service panel
 --------------------------------------
 
@@ -167,34 +255,15 @@ Variables
   - **Type** Database Object.
   - **Available**: when the service is running on a device.
 
-- ``result``
+- ``devices``
 
-  - **Meaning**: this is the result of the current service.
-  - **Type** Dictionary.
-  - **Available**: after a service has run.
-
-- ``settings``
-
-  - **Meaning**: eNMS settings, editable from the top-level menu.
-    It is initially set to the content of ``settings.json``.
-  - **Type** Dictionary.
+  - **Meaning**: the full list of devices for the service.
+  - **Type**: List of database objects.
   - **Available**: Always.
 
-- ``parent_device``
+- ``get_result`` (see :ref:`get_result`)
 
-  - **Meaning**: Parent device used to compute derived devices.
-  - **Type** Database Object.
-  - **Available**: when the iteration mechanism is used to compute derived devices.
-
-- ``workflow`` (only in a **workflow**)
-
-  - **Meaning**: current workflow.
-  - **Type** Database Object.
-  - **Available**: when the service runs inside a workflow.
-
-- ``get_result`` (only in a **workflow**, see :ref:`get_result`)
-
-  - **Meaning**: Fetch the result of a service in the workflow that have already been executed.
+  - **Meaning**: Fetch the result of a service in the workflow that has already been executed.
   - **Type** Function.
   - **Return Type** Dictionary
   - **Available**: when the service runs inside a workflow.
@@ -204,20 +273,72 @@ Variables
     - ``device`` (**optional**) Name of the device, when you want to get the result of the service for a
       specific device.
     - ``workflow`` (**optional**) If your workflow has multiple subworkflows, you can specify
-      a device in case you want to get the result of the service for a specific device.
+      a subworkflow to get the result of the service for a specific subworkflow.
 
-- ``set_var`` **(only in a workflow)**
+- ``get_var``
 
-  - **Meaning**: Save a variable in the workflow payload for later.
+  - **Meaning**: Retrieve a value by ``name`` that was previously saved in the workflow.  Use ``set_var`` to save values.  Always
+    use the same ``device`` and/or ``section`` values with ``get_var`` that were used with the original ``set_var``.
+
   - **Type** Function.
   - **Return Type** None
-  - **Available**: when the service runs inside a workflow.
+  - **Available**: always.
   - **Parameters**:
 
-    - First argument: Name of the variable
-    - Second argument: Value
+    - ``name`` Name of the variable
     - ``device`` (**optional**) The value is stored for a specific device.
     - ``section`` (**optional**) The value is stored in a specific "section".
+
+- ``log``
+  - **Meaning**: Write a
+  - **Type**:
+  - **Return Type**: None
+  - **Available**: always.
+  - **Parameters**:
+
+    - **severity**: (**string**) Valid values in escalating priority order: **info**, **warning**, **error**, **critical**.
+    - **message**: (**string**) Verbiage to be logged.
+    - **device**: (**string**, **optional**) Associate log message to a specific device.
+    - **app_log**: (**boolean**, **optional**) Write log message to application log in addition to custom logger.
+    - **logger**: (**string**, **optional**) When specified, the log message is written to the named custom logger
+      instead of the application log. Set **app_log** = True to send log message to both the custom and application logs.
+      Contact the administrator to create a custom logger, if needed.
+
+- ``parent_device``
+
+  - **Meaning**: parent device used to compute derived devices.
+  - **Type** Database Object.
+  - **Available**: when the iteration mechanism is used to compute derived devices.
+
+- ``result``
+
+  - **Meaning**: this is the result of the current service.
+  - **Type** Dictionary.
+  - **Available**: after a service has run.
+
+- ``set_var``
+
+  - **Meaning**: Save a value by ``name`` for use later in a workflow.  When ``device`` and/or ``section`` is specified, a unique
+    value is stored for each combination of device and section.  Use ``get_var`` for value retrieval.
+  - **Type** Function.
+  - **Return Type** None
+  - **Available**: always.
+  - **Parameters**:
+
+    - ``name`` Name of the variable
+    - ``device`` (**optional**) The value is stored for a specific device.
+    - ``section`` (**optional**) The value is stored in a specific "section".
+
+Variables saved globally (i.e. set_var("var1", value) and for a device (i.e. set_var("var2", device=device.name)) are
+made available within every Python code can be used.  Only device specific variables for the current device are
+available.  Device specific variables override global variables of the same name.
+
+- ``settings``
+
+  - **Meaning**: eNMS settings, editable from the top-level menu.
+    It is initially set to the content of ``settings.json``.
+  - **Type** Dictionary.
+  - **Available**: Always.
 
 - ``send_email`` lets you send an email with optional attached file. It takes the following parameters:
 
@@ -243,6 +364,12 @@ Variables
         file_content=file_content
     )
 
+- ``workflow``
+
+  - **Meaning**: current workflow.
+  - **Type** Database Object.
+  - **Available**: when the service runs inside a workflow.
+
 Substitution fields
 *******************
 
@@ -251,6 +378,8 @@ inside double curved brackets (``{{your python code}}``).
 For example, the URL of a REST call service is a substitution field. If the service is running on device
 targets, you can use the global variable ``device`` in the URL.
 When the service is running, eNMS will evaluate the python code in brackets and replace it with its value.
+See `Using python code in the service panel`_ for the full list of variables and functions available within substitution
+fields.
 
 .. image:: /_static/automation/services/variable_substitution.png
    :alt: Variable substitution
@@ -267,12 +396,13 @@ Running the service on two devices ``D1`` and ``D2`` will result in sending the 
 Python fields
 *************
 
-Python fields, marked with a light red background, accept pure python code only.
+Python fields, marked with a light red background, accept valid python code.
 
-- In the ``Device Query`` field of the "Devices" section of a service. This field lets the user define the targets of a service programmatically.
-- In the ``Skip Service if True`` field of the "Workflow" section of a service. This field lets the user define whether or not a service should be skipped programmatically.
-- In the ``Query`` field of the Variable Extraction Service.
-- In the code of a Python Snippet Service.
+- In the ``Device Query`` field of the "Devices" section of a service. An expression that evaluates to an iterable
+  containing the name(s) or IP address(es) of the desired inventory devices.
+- In the ``Skip Service if True`` field of the "Workflow" section of a service.  The expression result is treated as a boolean.
+- In the ``Query`` field of the Variable Extraction Service.  The expression result is used as the extracted value.
+- In the code of a Python Snippet Service, or the ``Preprocessing`` and ``Postprocessing`` field on every service.
 
 .. _Custom Services:
 
@@ -282,7 +412,7 @@ Custom Services
 In addition to the services provided by default, you are free to create your own services.
 When the application starts, it loads all python files in ``eNMS / eNMS / services`` folder.
 If you want your custom services to be in a different folder, you can set a different path in the
-:ref:`settings`, section ``paths``.
+``settings``, section ``paths``.
 Creating a service means adding a new python file in that folder.
 You are free to create subfolders to organize your own services any way you want:
 eNMS will automatically detect them.
@@ -299,15 +429,17 @@ There are two types of runs:
 
 - Standard run: uses the service properties during the run.
 - Parameterized run: a window is displayed with all properties initialized to the service
+
 properties. You can change any property for the current run, but these changes won't be saved
 back to the service properties.
 
 Results
 *******
 
-Results are stored for each run of the service / workflow.
-The results are displayed as a JSON object. If the service ran on several device, you can display the results for a
+A separate result is stored for each run of a service / workflow, plus a unique result for every device and for every
+service and subworkflow within a workflow.
+Each result is displayed as a JSON object. If the service is run on several devices, you can display the results for a
 specific device, or display the list of all "failed" / "success" device.
-In the event that retries are configured, the Logs dictionary will contain an overall results section,
+In the event that retries are configured, the results dictionary will contain an overall results section,
 as well as a section for each attempt, where failed and retried devices are shown in subsequent sections
 starting with attempt2.

--- a/docs/automation/workflows.rst
+++ b/docs/automation/workflows.rst
@@ -5,7 +5,12 @@ Workflow System
 A workflow is a graph of services connected with ``success`` and ``failure`` edges.
 If a service is executed successfully, the workflow continues down the ``success`` path to the next service,
 otherwise it goes down the ``failure`` path. A workflow is considered to have run successfully if the "End"
-service is reached.
+service is reached. For this reason, a ``failure`` edge should be used for:
+
+  - Recovery from a failure, using some corrective action, that allows the workflow to then continue on the ``success``
+    path
+  - Cleanup or finalization of the state of a device, following the failure, before the workflow ends
+
 Workflows are managed from the :guilabel:`Workflow Builder`.
 When a workflow is running, the results are automatically updated in real-time in the workflow builder.
 
@@ -22,12 +27,15 @@ Workflow Builder
       will be added to the workflow.
     - On the second row, you can change the mode to "Edge creation" and select which type of edge you want to create.
 
-- Section 2: edit and duplicate the current workflow, create a new workflow, add existing services to the
+- Section 2: edit and duplicate the current workflow, create a new top-level workflow, add existing services to the
   workflow, create labels, skip or unskip services, and delete selected services and edges.
-- Section 3: run or pause a workflow, and display the workflow logs and results.
+- Section 3: run or stop a workflow, and display the workflow logs and results.
 - Section 4: refresh the workflow, zoom and unzoom, move to the previous or next workflow, and move to the
   selected subworkflow.
-- Section 5: choose which workflow to display, and which results.
+- Section 5: choose which workflow to display, and which results.  The ``Latest Runtime`` results selection will make
+  workflow builder continue refreshing on the most recent run activity for this particular workflow on this instance of
+  eNMS.  The ``Normal Display`` will show the workflow without run results.  Selecting a specific runtime result will
+  prevent refreshing for any new runtimes and will continue to display that historical run.
 
 .. note::
 
@@ -38,22 +46,22 @@ Workflow Devices
 ----------------
 
 The devices used when running a workflow depend on the workflow ``Run Method`` that you can configure in the
-edit panel, section ``Devices``.
+edit panel, section ``Targets``.
 There are three run methods for a workflow:
 
 Device by device
 ****************
 
   - Uses the devices configured at **workflow** level.
-  - Multiprocessing must be enabled at **workflow** level.
-  - Workflow will run for each device independently, one at a time if multiprocessig is disabled
+  - Multiprocessing, if desired, must be enabled at **workflow** level.
+  - Workflow will run for each device independently: one at a time if multiprocessing is disabled, or
     in parallel otherwise.
 
 Service by service using workflow targets
 *****************************************
 
   - Uses the devices configured at **workflow** level.
-  - Multiprocessing must be enabled at **service** level.
+  - Multiprocessing, if desired, must be enabled at **service** level.
   - The workflow will run one service at a time, but each device can follow a different path depending on
     the results of each service for that device.
 
@@ -61,7 +69,7 @@ Service by service using service targets
 ****************************************
 
   - Uses the devices configured at **service** level.
-  - Multiprocessing must be enabled at **service** level.
+  - Multiprocessing, if desired, must be enabled at **service** level.
   - The workflow will run one service at a time. A service is considered successful if it ran successfully
     on all of its targets (if it fails on at least one target, it is considered to have failed).
 
@@ -74,35 +82,37 @@ Using the result of previous services
 *************************************
 
 When a service starts, you can have access to the results of all services in the workflow that have already
-been executed with a special function called ``get_result``. The result of a service is the dictionary that is
-returned by the ``job`` function of the service, and calling ``get_result`` will return that dictionary.
+been executed with a special function called ``get_result``. This and other functions are available for use in form
+fields that support variable substitution (designated in the UI with a colored tint). The result of a service is the
+dictionary that is returned by the ``job`` function of the service, and calling ``get_result`` will return that dictionary.
 There are two types of results: top-level and per-device. If a service runs on 5 devices, 6 results will be
 created: one for each device and one top-level result for the service itself.
 
 Examples:
 
 - ``get_result("get_facts")`` Get the top-level result for the service ``get_facts``
-- ``get_result("get_interfaces", device="Austin")`` Get the result of the device ``Austin`` for
-  ``get_interfaces``
-- ``get_result("get_interfaces", device=device.name)`` Get the result of the current device for
-  ``get_interfaces``
+- ``get_result("get_interfaces", device="Austin")`` Get the result of the device ``Austin`` for the
+  ``get_interfaces`` service.
+- ``get_result("get_interfaces", device=device.name)`` Get the result of the current device for the
+  ``get_interfaces`` service.
 - ``get_result("Payload editor")["runtime"]`` Get the ``runtime`` key of the top-level result of the
   ``Payload editor`` service.
 
-The ``get_result`` function everywhere python code is accepted.
+The ``get_result`` function works everywhere that python code is accepted.
 
 
 Saving and retrieving values in a workflow
 ------------------------------------------
 
-You can define variables in the payload with the ``set_var`` function, and retrieve data from the payload
-with the ``get_var`` function using the first postional argument and the same optional arguments defined in ``set_var``.
-If neither of the opotional arguments are used the variable will be global. 
+You can define variables in the payload with the ``set_var`` function, and retrieve those variables' data from the payload
+with the ``get_var`` function using the first positional argument (the variable name) and the same optional arguments
+defined in ``set_var``. If neither of the optional arguments are used the variable will be global.
 
-- The first argument for set_var is postional and names the variable being set.
-- The second argument for set_var is postional and assigns the value for the variable.
-- An optional arugment for set_var uses keyword "device", which can scope the variable to the device the service is using when variable is set.
-- An optional argument for set_var uses keyword "section", which can scope the variable as user defines.
+- The first argument for set_var is positional and names the variable being set.
+- The second argument for set_var is positional and assigns the value for the variable.
+- An optional argument for set_var uses keyword "device", which can scope the variable to the device the service is
+  using when the variable is set.
+- An optional argument for set_var uses keyword "section", which can scope the variable to a user provided custom scope.
 
 Examples:
 
@@ -139,10 +149,18 @@ until both ``Get Facts`` and ``Get Interfaces`` have been executed.
 Workflow Restartability
 ***********************
 
-A workflow can be restarted with any services set as "Entry points"
-and with the payload from a previous runs.
-This is useful if you are testing a workflow with a lot of services, and you don't want it to
-restart from scratch all the time.
+A workflow can be restarted with any services set as "Entry points" and with the runtime payload from a previous run.
+This is useful if you are testing a workflow with a lot of services, or some of the services in the workflow are not
+idempotent, so you don't want it to restart from the Start service each time.
+
+.. note::
+
+   A restart can be performed inside a subworkflow such that the runtime result of the parent workflow is pulled in to
+   satisfy variable dependencies.
+
+   The target device list for restarting is limited to the original target list as specified in the workflow or service.
+   You cannot change the target list, for example to only failed devices, and restart a workflow that picks up and continues
+   a historical runtime.
 
 Connection cache
 ****************
@@ -160,7 +178,7 @@ Waiting times
 Services and Workflows have a ``Waiting time`` property: this tells eNMS how much time it should wait after
 the service has run before it begins the next service.
 
-A service can also be configured to "retry"  if the results returned are not as designed.
+A service can also be configured to "retry" if the results returned are not as designed.
 An example execution of a service in a workflow, in terms of waiting times and retries, is as follows:
 
 ::

--- a/docs/base/features.rst
+++ b/docs/base/features.rst
@@ -29,7 +29,7 @@ You can click on a device to display its properties, configuration, or start an 
   :alt: Geographical View
   :align: center
 
-Colocated devices can be grouped into geographical sites (campus, dacacenter, ...),
+Colocated devices can be grouped into geographical sites (campus, datacenter, ...),
 and displayed logically with a force-directed layout.
 
 .. image:: /_static/base/site_view.png
@@ -57,7 +57,7 @@ Oxidized/Rancid with the following features:
   - Download device configuration to a local text file.
   - Use the REST API support to return a specified device’s configuration.
   - Export all configurations to a remote Git repository (e.g. Gitlab)
-  - View differences between various revisions of a configuration with a git-style differences
+  - View git-style differences between various revisions of a configuration
 
 .. image:: /_static/base/configuration_search.png
    :alt: Configuration Search

--- a/docs/base/installation.rst
+++ b/docs/base/installation.rst
@@ -4,8 +4,15 @@ Installation
 
 eNMS is designed to run on a **Unix server** with Python **3.6+**.
 
+.. contents::
+  :local:
+  :depth: 1
+
+|
+
+
 First steps
------------
+###########
 
 ::
 
@@ -25,27 +32,31 @@ First steps
  # or with gunicorn
  gunicorn --config gunicorn.py app:app
 
-Production mode
----------------
+|
 
-To start eNMS in production mode, you must change the value of the  "config_mode" in the settings.json file, and set the secret
-key.
+Production mode
+###############
+
+To start eNMS in production mode, you must change the value of the "config_mode" from "debug" to "production" in the
+settings.json file, and set the secret key.
 
 ::
 
  # set the SECRET_KEY environment variable
  export SECRET_KEY=value-of-your-secret-key
 
-All credentials should be stored in a Hashicorp Vault: the settings variable ``active`` under the ``vault`` section of the settings
-tells eNMS that a Vault has been setup and can be used.
+All credentials should be stored in a Hashicorp Vault: the settings variable ``active`` under the ``vault`` section of
+the settings tells eNMS that a Vault has been setup and can be used.
 Follow the manufacturer's instructions and options for how to setup a Hashicorp Vault.
 
 You must tell eNMS how to connect to the Vault with
-  - the ``address`` settings variable
+  - the ``VAULT_ADDRESS`` environment variable
   - the ``VAULT_TOKEN`` environment variable
 
 ::
 
+ # set the VAULT_ADDRESS environment variable
+ export VAULT_ADDRESS=url of the vault
  # set the VAULT_TOKEN environment variable
  export VAULT_TOKEN=vault-token
 
@@ -62,32 +73,45 @@ This mechanism is disabled by default. To activate it, you need to:
 
 .. _Settings:
 
-Settings
--------------
+|
 
-The settings are divided into:
+Settings file
+#############
+
+The ``/setup/settings.json`` file includes:
 
 - Environment variables for all sensitive data (passwords, tokens, keys). Environment variables are exported
-  from Unix with the ``export`` keyword: ``export VARIABLE_NAME=value``.
-- Public variables defined in the ``settings.json`` file, and later modifiable from the administration
-  panel.
+  from Unix with the ``export`` keyword: ``export VARIABLE_NAME=value``. Environment variables include:
 
-Section ``app``
-***************
+::
+
+    - SECRET_KEY = secret_key
+    - MAIL_PASSWORD = mail_password
+    - TACACS_PASSWORD = tacacs_password
+    - SLACK_TOKEN = slack_token
+
+- Public variables defined in the ``settings.json`` file, and later modifiable from the administration
+  panel. Note that changing settings from the administration panel do not currently cause the settings.json file
+  to be rewritten.
+
+.. _app-settings:
+
+Settings ``app`` section
+**************************
 
 - ``address`` (default: ``""``) The address is needed when eNMS needs to provide a link back to the application,
   which is the case with GoTTY and mail notifications. When left empty, eNMS will try to guess the URL. This might
-  not work all the time depending on your environment (nginx configuration, proxy, ...)
+  not work consistently depending on your environment (nginx configuration, proxy, ...)
 - ``config_mode`` (default: ``"debug"``) Must be set to "debug" or "production".
 - ``create_examples`` (default: ``true``) By default, eNMS will create a network topology and a number of services
-  and workflows as an example of what you can do.
+  and workflows as examples of what you can do.
 - ``documentation_url`` (default: ``"https://enms.readthedocs.io/en/latest/"``) Can be changed if you want to host your
   own version of the documentation locally. Points to the online documentation by default.
 - ``git_repository`` (default: ``""``) Git is used as a version control system for device configurations: this variable
   is the address of the remote git repository where eNMS will push all device configurations.
 
-Section ``cluster``
-*******************
+Settings ``cluster`` section
+*******************************
 
 - ``active`` (default: ``false``)
 - ``id`` (default: ``true``)
@@ -95,8 +119,8 @@ Section ``cluster``
 - ``scan_protocol`` (default: ``"http"``)
 - ``scan_timeout`` (default: ``0.05``)
 
-Section ``database``
-********************
+Settings ``database`` section
+*******************************
 
 - ``url`` (default: ``"sqlite:///database.db?check_same_thread=False"``) `SQL Alchemy database URL
   <https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls/>`_, configured
@@ -107,8 +131,8 @@ Section ``database``
 - ``small_string_length`` (default: ``255``) Length of a small string in the database.
 - ``small_string_length`` (default: ``32768``) Length of a large string in the database.
 
-Section ``ldap``
-****************
+Settings ``ldap`` section
+****************************
 
 If LDAP/Active Directory is enabled and the user doesn't exist in the database yet, eNMS tries to authenticate against
 LDAP/AD using the `ldap3` library, and if successful, that user gets added to eNMS locally.
@@ -122,23 +146,13 @@ LDAP/AD using the `ldap3` library, and if successful, that user gets added to eN
   matched user to determine if the user is allowed to log in.
 
 .. note:: Failure to match memberOf attribute output against ``admin_group`` results in a valid ldap user
-  within the ``basedn`` being given default permissions (i.e., Read Only group).  They will still
-  be able to log in. If a memberOf attribute matches the ``admin_group``, they will be given
-  Admin permissions.
-.. note:: Because eNMS saves the user credentials for LDAP and TACACS+ into the Vault, if a user's credentials expire
-  due to password aging, that user needs to login to eNMS in order for the updated credentials to be replaced in Vault storage.
-  In the event that services are already scheduled with User Credentials, these might fail if the credentials
-  are not updated in eNMS.
+  within the ``basedn`` being denied access on login. If a memberOf attribute matches the ``admin_group``, they
+  will be given Admin permissions.
+.. note:: eNMS does not store the credentials of LDAP and TACACS users; however, those users are listed in the
+  Admin / Users panel.
 
-Section ``logging``
-*******************
-
-- ``log_level`` (default: ``"debug"``) Gunicorn log level.
-- ``loggers`` (default: ``{"requests": "info", "urllib3": "info"}``) Change the default log levels of eNMS loggers. By default,
-eNMS will set the requests and urllib3 library to a log level of "info".
-
-Section ``mail``
-****************
+Settings  ``mail`` section
+****************************
 
   - ``server`` (default: ``"smtp.googlemail.com"``)
   - ``port`` (default: ``587``)
@@ -146,22 +160,29 @@ Section ``mail``
   - ``username`` (default: ``"eNMS-user"``)
   - ``sender`` (default: ``"eNMS@company.com"``)
 
-Section ``mattermost``
-**********************
+Settings ``mattermost`` section
+**********************************
 
 - ``url`` (default: ``"https://mattermost.company.com/hooks/i1phfh6fxjfwpy586bwqq5sk8w"``)
 - ``channel`` (default: ``""``)
 - ``verify_certificate`` (default: ``true``)
 
-Section ``paths``
-*****************
+Settings  ``paths`` section
+*****************************
 
-- ``custom_code`` (default: ``""``)
-- ``custom_services`` (default: ``""``) Path to a folder that contains :ref:`Custom Services`.
-- ``playbooks`` (default: ``""``)
+- ``files`` (default:``""``) Path to eNMS managed files needed by services and workflows. For example, files to upload
+  to devices.
+- ``custom_code`` (default: ``""``) Path to custom libraries that can be utilized within services and workflows
+- ``custom_services`` (default: ``""``) Path to a folder that contains :ref:`Custom Services`. These services are added
+  to the list of existing services in the Automation Panel when building services and workflows.
+- ``playbooks`` (default: ``""``) Path to where Ansible playbooks are stored so that they are
+  choosable in the Ansible Playbook service.
 
-Section ``requests``
-********************
+Settings ``requests`` section
+********************************
+
+Allows for tuning of the Python Requests library internal structures for connection pooling. Tuning
+these might be necessary depending on the load on eNMS.
 
 - Pool
 
@@ -176,55 +197,63 @@ Section ``requests``
     - ``connect`` (default: ``2``)
     - ``backoff_factor`` (default: ``0.5``)
 
-Section ``security``
-********************
+Settings  ``security`` section
+*********************************
 
 - ``hash_user_passwords`` (default: ``true``) All user passwords are automatically hashed by default.
-- ``forbidden_python_libraries`` (default: ``["eNMS","os","subprocess","sys"]``) There are a number of places in the UI where the user
-is allowed to run custom python scripts. You can configure which python libraries cannot be imported for security reasons.
+- ``forbidden_python_libraries`` (default: ``["eNMS","os","subprocess","sys"]``) There are a number of places in the UI
+  where the user is allowed to run custom python scripts. You can configure which python libraries cannot be imported
+  for security reasons.
 
-Section ``slack``
-*****************
+Settings ``slack`` section
+****************************
 
 - ``channel`` (default: ``""``)
 
-Section ``ssh``
-***************
+.. _ssh-settings:
+
+Settings ``ssh`` section
+************************
 
 - ``port_redirection`` (default: ``false``)
 - ``bypass_key_prompt`` (default: ``true``)
+- ``port`` (default: ``-1``)
 - ``start_port`` (default: ``9000``)
 - ``end_port`` (default: ``91000``)
+- ``enabled``
 
-Section ``syslog``
-******************
+    - ``web`` (default: ``true``)   Enables device terminal connections in a browser tab
+    - ``desktop`` (default: ``true``)  Enables device terminal connections from your desktop software that tunnels
+      through eNMS to the device
+
+Settings ``syslog`` section
+*****************************
 
 - ``active`` (default: ``false``)
 - ``address`` (default: ``"0.0.0.0"``)
 - ``port`` (default: ``514``)
 
-Section ``tacacs``
-******************
+Settings ``tacacs`` section
+*****************************
 
 - ``active`` (default: ``false``)
 - ``address`` (default: ``""``)
-- ``port`` (default: ``514``)
 
-Section ``vault``
-*****************
+Settings ``vault`` section
+****************************
 
 For eNMS to use a Vault to store all sensitive data (user and network credentials), you must set
-the ``active`` variable to ``true``, provide an address and export 
+the ``active`` variable to ``true``, provide an address and export
 
 **Public variables**
 
 - ``active`` (default: ``false``)
-- ``address`` (default: ``"http://127.0.0.1:8200"``)
 - ``unseal`` (default: ``false``) Automatically unseal the Vault. You must export the keys as
   environment variables.
 
 **Environment variables**
 
+- ``VAULT_ADDRESS``
 - ``VAULT_TOKEN``
 - ``UNSEAL_VAULT_KEY1``
 - ``UNSEAL_VAULT_KEY2``
@@ -232,8 +261,10 @@ the ``active`` variable to ``true``, provide an address and export
 - ``UNSEAL_VAULT_KEY4``
 - ``UNSEAL_VAULT_KEY5``
 
-Section ``view``
-****************
+Settings ``view`` section
+***************************
+
+Controls the default view for where the map is initially displayed in the Visualization panels
 
 - ``longitude`` (default: ``-96.0``)
 - ``latitude`` (default: ``33.0``)
@@ -241,12 +272,63 @@ Section ``view``
 - ``tile_layer`` (default: ``"osm"``)
 - ``marker`` (default: ``"Image"``)
 
-Private settings
-****************
 
-::
+Logging file
+############
 
-  - SECRET_KEY=secret_key
-  - MAIL_PASSWORD=mail_password
-  - TACACS_PASSWORD=tacacs_password
-  - SLACK_TOKEN=slack_token
+Logging settings exist in separate file: ``/setup/logging.json``. This file is directly passed into the Python Logging library,
+so it uses the Python3 logger file configuration syntax for your version of Python3. Using this file, the administrator
+can configure additional loggers and logger destinations as needed for workflows.
+
+By default, the two loggers are configured:
+  - The default logger has handlers for sending logs to the stdout console as well as a rotating log file ``logs/enms.log``
+  - A security logger captures logs for: User A ran Service/Workflow B on Devices [C,D,E...] to log file ``logs/security.log``
+
+And these can be reconfigured here to forward through syslog to remote collection if desired.
+
+Additionally, the ``external loggers`` section allows for changing the log levels for the various libraries used by eNMS
+
+
+Properties file
+###############
+
+The ``/setup/properties.json`` file includes:
+
+  1. Allowing for additional custom properties to be defined in eNMS for devices. In this way, eNMS device inventory can be extended to include additional columns/fields
+  #. Allowing for additional custom parameters to be added to services and workflows
+  #. Controlling which parameters and widgets can be seen from the Dashboard
+  #. Controlling which column/field properties are visible in the tables for device and link inventory, configuration, pools, as well as the service, results, and task browsers
+
+|
+
+properties.json custom device addition example:
+    - Keys under {"custom": { "device": {
+        - name the custom attribute being added.
+        - Keys/Value pairs under the newly added custom device attribute device_status.
+            - "pretty_name":"Default Username", *device attribute name to be displayed in UI*
+            - "type":"string", *data type of attribute*
+            - "default":"None", *default value of attribute*
+            - "private": true *optional - is attribute hidden from user*
+    - Keys under "tables" : { "device" : [ {  & "tables" : { "configuration" : [ {
+        - Details which attributes to display in these table, add custom attributes here
+        - Keys/Value pairs for tables
+            - "data":"device_status", *attribute created in custom device above*
+            - "title":"Device Status", *name to display in table*
+            - "search":"text", *search type*
+            - "width":"80%", *optional - text alignment, other example "width":"130px",*
+            - "visible":false, *default display option*
+            - "orderable": false *allow user to order by this attribute*
+    - Values under "filtering" : { "device" : [
+        - details which attributes to use for filtering
+        - you will need to add any custom device attributes name to this list for filtering
+
+
+
+
+RBAC file
+#########
+
+The ``/setup/rbac.json`` file allows configuration of:
+
+  - Which user roles have access to each of the controls in the UI
+  - Which user roles have access to each of the REST API endpoints

--- a/docs/base/release_notes.rst
+++ b/docs/base/release_notes.rst
@@ -15,8 +15,7 @@ Version 3.21.3
 
 - Add new plugins mechanism
 - Fix bug help panel open when clicking a field or label
-- Add error message in the logs when a service is run in per device mode but no
-devices have been selected.
+- Add error message in the logs when a service is run in per device mode but no devices have been selected.
 - Add default port of 22 for TCP ping in ping service
 - Disable edit panel on double-click for start/end services of a workflow
 - Fix invalid request bug when pressing enter after searching the "add services to workflow" panel
@@ -90,7 +89,7 @@ Version 3.21
 - Ability to display config older config from GIT
 - Ability to compare currently displayed config/data to any point in time in the past.
 - Syntax highlight option: ability to highlight certain keywords based on regular expression match,
-defined in eNMS/static/lib/codemirror/logsMode. Can be customized.
+  defined in eNMS/static/lib/codemirror/logsMode. Can be customized.
 - New logging property to configure log level for a service or disable logging.
 - Fix bug when typing invalid regex for table search (eg "(" )
 - Dont display Start / End services in service table
@@ -101,7 +100,7 @@ defined in eNMS/static/lib/codemirror/logsMode. Can be customized.
 - Add timestamp for session logs
 - Add device result counter in result tree window
 - Move to optional_requirements file and catch import error of all optional libraries:
-ansible, hvac, ldap3, pyats, pynetbox, slackclient>=1.3,<2, tacacs_plus
+  ansible, hvac, ldap3, pyats, pynetbox, slackclient>=1.3,<2, tacacs_plus
 - Fix Napalm BGP example service
 - Fix 404 custom passwords logs from Vault
 - Encrypt and decrypt all data going in and out of the vault (b64 / Fernet)
@@ -111,20 +110,20 @@ ansible, hvac, ldap3, pyats, pynetbox, slackclient>=1.3,<2, tacacs_plus
 - all post processing mode: "run on success" / "run on failure" / "run all the time" selector
 - Support functions and classes with set_var / get_var 
 - Fix front end bug when displaying the results if they contain a python SET (invalid JSON):
-all non-JSON compliant types are now automatically converted to a string when saving the results in the
-database, and a warning is issue in the service logs.
+  all non-JSON compliant types are now automatically converted to a string when saving the results in the
+  database, and a warning is issue in the service logs.
 - Add superworkflow mechanism
 - Add jump on connect support
 - Add log deletion support from CLI interface
 - Forbid import of "os", "subprocess" and "sys" in a python code area in service panel
-(snippet, pre/postprocessing, etc)
+  (snippet, pre/postprocessing, etc)
 - Refactor logging configuration: all the logging are now configured from a file in setup: logging.json
-Besides, the log function in a workflow takes a new parameter "logger" where you can specify a logger name.
-This means you can first add your own loggers in logging.json, then log to them from a workflow.
+  Besides, the log function in a workflow takes a new parameter "logger" where you can specify a logger name.
+  This means you can first add your own loggers in logging.json, then log to them from a workflow.
 - Remove CLI fetch, update and delete endpoint (curl to be used instead if you need it from the VM)
 - Improve workflow stop mechanism: now hitting stop will try to stop ASAP, not just after the on-going
-service but also after the on-going device, or after the on-going retry (e.g many retries...).
-Besides stop should now work from subworkflow too.
+  service but also after the on-going device, or after the on-going retry (e.g many retries...).
+  Besides stop should now work from subworkflow too.
 
 MIGRATION:
 In services, "result_postprocessing" -> "postprocessing"
@@ -170,7 +169,7 @@ Version 3.20.1
 - Add all service reference in submenu in workflow builder
 - Add entry to copy service name as reference.
 - Add new feature to accept a dictionary in iteration values. When a dictionary is used, the keys are used as the 
-name of the iteration step in the results.
+  name of the iteration step in the results.
 - Iteration variable are now referred to as global variable,
 - Catch all exceptions in rest api to return proper error 500 (device not found for get configuration, etc)
 - Fix bug position of shared services resetted after renaming workflow
@@ -193,19 +192,21 @@ Version 3.20
 
 - Add configuration management mechanism
 - New Table properties mechanism: all table properties are displayed in a JSON file: you can configure which ones
-appear in each table by default, whether they are searchable or not, etc, their label in the UI, etc.
-You will need to add your CUSTOM properties to that file if you want them to appear in the table.
+  appear in each table by default, whether they are searchable or not, etc, their label in the UI, etc.
+  You will need to add your CUSTOM properties to that file if you want them to appear in the table.
 - Same with dashboard properties and pool properties
 - New Column visibility feature
 - New Configuration Management Mechanism
 - RBAC
 - Refactoring of the search system: next to the input, old "Advanced Search" button now dedicated
-to relationship. Everything is now persisted in the DOM.
+  to relationship. Everything is now persisted in the DOM.
 
 MIGRATION:
 - In netmiko configuration backup service, rename:
-  * "configuration" -> "configuration_command"
-  * "operational_data" -> "operational_data_command"
+
+  - "configuration" -> "configuration_command"
+  - "operational_data" -> "operational_data_command"
+
 - Moved ansible, pyats to a dedicated file called "requirements_optional.txt":
 
 Version 3.19
@@ -244,7 +245,7 @@ Version 3.18.2
 - Allow restart from top-level workflow when restarting from a subworkflow service
 - New "Skip value" property to decide whether skip means success or failure
 - Fix the workflow builder progress display when devices are skipped. Now eNMS shows how many devices
-are skipped, and it no longer shows anything when it's 0 ("0 failed", "0 passed" etc are no longer displayed)
+  are skipped, and it no longer shows anything when it's 0 ("0 failed", "0 passed" etc are no longer displayed)
 - Netmiko session log code improvement for netmiko validation / prompt service
 
 Version 3.18.1

--- a/docs/inventory/network_visualization.rst
+++ b/docs/inventory/network_visualization.rst
@@ -44,7 +44,7 @@ Marker Types
 ------------
 
 There are three different types of markers: images, circle, and circle marker.
-Displaying images can have an impact on performances above 10K devices;
+Displaying images can have an impact on performance above 10K devices;
 in that case, it is best to use circles or circle markers for scalability.
 
 .. image:: /_static/inventory/network_visualization/circle_markers.png
@@ -57,10 +57,12 @@ You can also configure in the settings which are used by default when you open t
 Site View
 ---------
 
-The geographical view displays all devices at their GPS coordinates. If several devices are colocated (e.g same building), they can be grouped in a site.
-A site is a pool with a longitude and a latitude. The site view displays all sites on the map.
+The geographical view displays all devices at their GPS coordinates. If several devices are colocated (e.g same
+building), they can be grouped in a site. A site is a pool with a longitude and a latitude. The site view displays all
+sites on the map.
 
-Clicking on a site will open a panel where all pool devices and links are organized in a logical and visually pleasing fashion using a force-based algorithm.
+Clicking on a site will open a panel where all pool devices and links are organized in a logical and visually
+pleasing fashion using a force-based algorithm.
 
 .. image:: /_static/base/site_view.png
    :alt: Site View

--- a/docs/inventory/pools.rst
+++ b/docs/inventory/pools.rst
@@ -2,135 +2,136 @@
 Pools
 =====
 
-Pools allow the user to create groups of objects. They can be used to filter the inventory tables and the view,
-but also to target an automation task to a specific subset of devices.
-A pool is defined as a combination of values for the properties of an object (in the inventory).
-For each value, you can decide whether the match is based on inclusion, equality, or regular expression.
+The Pools feature allow the user to create groups of Device or Link objects. They can be used to filter the Pool Inventory table
+and in the :guilabel:`Visualization -> Network` view screen. Pools are also used to target an automation task to a specific, defined,
+group ("pool") of devices. A pool is defined as a combination of properties values of device or link  object. When defining a Pool,
+for each property value, decide, whether the match is based on inclusion, equality, or regular expression.
 
-If the properties of an inventory object matches the pool properties, the object will be automatically added to the pool.
+If the properties of a device or link object matches the pool properties, that object will be automatically added to the pool.
 
 Pool Management
 ---------------
 
-Pools can be created, updated, duplicated and deleted from :guilabel:`Inventory / Pools`, and they can be
-edited to manually select devices and links instead of using criteria based on properties.
+Pools can be created, updated, duplicated and deleted from :guilabel:`Inventory -> Pools`. They can be edited to manually
+select devices and links instead of using criteria based on properties.
 
 .. image:: /_static/inventory/pools/pool_table.png
    :alt: Pool Management
    :align: center
 
-Additionally, a logical view of a pool is available using the ``Internal View`` button.
+A logical view of a pool can be displayed using the ``Internal View`` button.
 
 .. image:: /_static/inventory/pools/pool_visualization.png
    :alt: Pool Internal View
    :align: center
 
-A first example
----------------
+Device Pool creation example
+----------------------------
 
 .. image:: /_static/inventory/pools/device_filtering.png
    :alt: Device Filtering
    :align: center
 
-This pool enforces the following conditions:
- * name: ``device.*`` --- this regular expression matches all devices whose name starts with ``device``.
- * subtype: ``Router|Switch`` --- matches routers and switches (devices whose subtype is either ``Router``, or ``Switch``).
- * vendor: ``Cisco`` --- for this property, the regular expression box is not ticked. This means the value must be exactly ``Cisco``.
+This pool enforces the Union of the following conditions:
+ * name: ``Washington.*`` --- Match is Inclusion; all devices whose name include ``Washington`` will be selected
+ * subtype: ``GATEWAY|PEER`` --- Match is Regular Expression; all devices having subtype ``GATEWAY`` and ``PEER`` will be selected
+ * vendor: ``Cisco`` --- Match is Equality; all devices whose vendor is ``Cisco`` will be selected
 
-In summary, all ``Cisco`` ``routers or switches`` whose name begins with ``device`` will match these conditions, and they will be a member of the pool.
+In summary, all ``Cisco`` ``GATEWAY and PEER`` whose name begins with ``Washington`` will match these conditions, and they will be
+members of the pool.
 
 .. note:: All properties left with empty fields are simply ignored.
 .. note:: Along with all properties of a device, you can use the device **Configuration** and 
   **Operational Data** as a constraint for the pool. Refer to the Configuration Management page
   for more information.
 
-A pool of links
----------------
+Links Pool creation example
+---------------------------
 
 .. image:: /_static/inventory/pools/link_filtering.png
    :alt: Link filtering
    :align: center
 
-This pool enforces the following conditions:
- * subtype: ``Ethernet link`` --- matches all Ethernet links.
- * source name: ``bnet6`` --- matches all links whose source is the device ``bnet6``.
+This pool enforces the union of the following conditions:
+ * subtype: ``Ethernet link`` --- Match is Equality; all Ethernet links will be selected
+ * source name: ``Washington.*`` --- Match is Inclusion; all links whose source is the device name include ``Washington`` will be selected
 
-In summary, all ``Ethernet`` links starting from the device ``bnet6`` will be part of the pool.
+In summary, all ``Ethernet`` links starting from devices with name that include ``Washington`` will be members of the pool.
 
-Default pools
+Default Pools
 -------------
 
 Three pools are created by default in eNMS:
 
-- "All objects": a pool that matches all devices and links.
-- "Devices only": matches all devices, no link.
-- "Links only": matches all links, no device.
+- "All objects": A pool that matches all Devices and Links.
+- "Devices only": A pool that matches all Devices, no Links.
+- "Links only": A pool that matches all Links, no Device.
 
 Pools based on Configuration
 ----------------------------
 
-Pools can be created by searching the configurations data collected from all of the devices, rather than just the Inventory parameters
-for each device. Of course, configuration collection must be configured and allowed to run at least once before the configurations can
-be searched for the pool.
+Pools can be created by searching the configurations data collected from all of the devices, rather than just the
+Inventory parameters for each device. Configuration collection must be, first, configured and then allowed to run
+at least once before the configurations can be searched upon for the Pool.
 
-Filter the view with a pool
+Filter the view with a Pool
 ---------------------------
 
-Pools can be used as filters for the inventory devices and links tables, as well as the geographical views. You can click on the ``Filter Devices`` and ``Filter Links`` buttons to open the "Advanced Search" panel.
-These panels both contain a ``Pools`` drop-down list (multiple selection) to filter objects in the view.
+Pools can be used as filters for Devices and Links tables on the geographical views :guilabel:`Visualization -> Network`. At the
+top of the screen, click on the filter button ``Devices`` or ``Link`` to open the "Filtering" panel. Both of these panels
+contain a ``Pools`` drop-down list (multiple selection) to filter objects in the view. Click the refresh button after
+selecting filter criteria.
 
 .. image:: /_static/inventory/pools/view_filter.png
    :alt: Pool filtering of the view
    :align: center
 
-Use a pool as target of a Service or a Workflow
+Use a Pool as target of a Service or a Workflow
 -----------------------------------------------
 
-You can select multiple devices, as well as multiple pools as targets.
+In "Step 3", select Device(s) and/or Pool(s) as target(s).
 
 .. image:: /_static/inventory/pools/target_pool.png
    :alt: Use a pool as a target
    :align: center
 
-Use a pool to restrict an eNMS user to a subset of objects
-----------------------------------------------------------
+Use a Pool to restrict a user to a subset of objects
+----------------------------------------------------
 
 From the :guilabel:`Admin / User Management` panel, you can select a pool used as a database filtering
 mechanism for a particular user.
 All mechanisms and all pages in eNMS will be restricted to the objects of that pool for that particular user.
-The exception is Service and Workflows that have been already configured to run against particular
+The exception is Service and Workflows that have been already configured to run against a particular
 set of devices and links. If those devices and links are outside of the pool that the user is restricted to,
 the user will still be able to see them.
 
 Pool recalculation
 ------------------
 
-A pool is automatically updated by eNMS:
+All Pools are subject to automatic updates by eNMS (contingent upon the fact that its 'Manually Defined' flag is NOT
+set) after creation:
 
-- after being created (as long as its 'manually defined' flag is not set)
+- When the eNMS starts up or restarts
+- When a device is manually added to the inventory
+- When a device is modified
+- When, after pulling or cloning the content from the git configuration repository
+- When a service runs that has `Update pools before running` selected in Step 3 Targets
+- When the `poller service` runs (service responsible for fetching all device configurations), ONLY the pools for which the device ``Current Configuration`` are not empty, are updated.
 
-All pools are updated (as long as their 'manually defined' flag is not set):
+To manually update a Pool:
 
-- when eNMS starts, or restarts
-- when a device is manually added to the inventory
-- when a device is modified
-- after pulling or cloning the content from the git configuration repository
-- when the `poller service` runs (service responsible for fetching all device configurations), all pools for which the device ``Current Configuration`` is not empty are updated (and only those).
-
-Pools are manually updated:
-
-- when you click on the update button of a pool in pool management
-- when you click on the "update all pools" in pool management
+- Click on the ``Update`` button of a desired pool in Pool Management table listing
+- Click on the ``Update all pools`` button at the top of Pool Management UI
 
 Manual definition and "Manually Defined" option
--------------------------------------------
+-----------------------------------------------
 
-By default, the devices and links within a pool are determined based on the pool properties.
-However, the ``Edit objects`` button lets you define the pool devices and links by selecting them directly instead.
-There are two ways to manually select the objects of a pool:
+Initially, by default, the devices and links within a pool are determined based on the pool properties. The individual
+pools can be edited by allowing the user to define the devices and links by selecting them directly and there are a
+couple of ways of doing this:
 
-- By selecting them from a drop-down list.
-- By copy/pasting a string made of devices' and links' names, separated by a comma.
+- Click on ``edit`` icon: Will allow user to modify the Device Properties and Link Properties.
+- Click on ``wrench`` icon: Will open a "Pool Object" screen to allow a user to copy/pasting a string of comma separated devices and links names as well as selecting devices and links from a drop-down menu field.
 
 .. image:: /_static/inventory/pools/manual_definition.png
    :alt: Manual definition of a pool
@@ -139,7 +140,6 @@ There are two ways to manually select the objects of a pool:
 .. note:: Pools with manually selected objects need to have the 'Manually Defined' checkbox selected.
   This prevents manually selected pools from being re-calculated based on pool criteria.
   If the user wants to run against a pool that has some criteria specified as well as some manually
-  specified devices, it is advised to have 2 pools-one with the criteria
-  specified and another with the manually selected devices.
-  When running a service, multiple pools and multiple devices can be specified, and the service will run
-  against all specified objects.
+  specified devices, it is advised to have 2 pools, one with the criteria specified and another with
+  the manually selected devices. When running a service, multiple pools and multiple devices can be
+  specified, and the service will run against all specified objects.

--- a/docs/inventory/web_connection.rst
+++ b/docs/inventory/web_connection.rst
@@ -2,37 +2,50 @@
 WebSSH Connection
 =================
 
-eNMS uses GoTTY to automatically start an SSH or Telnet session to any device.
-GoTTY is a terminal sharing web solution that can be found on github: https://github.com/yudai/gotty
+WebSSH allows the connection to a device via eNMS. Where eNMS handles the establishment of the connection to the device 
+using the information stored in the inventory.
+eNMS uses GoTTY to automatically start an SSH or Telnet session to a device in the inventory.
+GoTTY is a terminal sharing web solution that can be found on github: https://github.com/yudai/gotty.
+
 
 Installation
 ------------
 
-There is no need to install GoTTY: it is shipped with eNMS by default in ``/eNMS/files/apps``.
-However, you must make sure that the file `gotty` can be executed (``chmod 755 gotty``).
+GoTTY is shipped with eNMS by default in the following directory ``/eNMS/files/apps``.
+You must make sure that the file `gotty` can be executed (``chmod 755 gotty``).
+
+To pass the login passwords to ssh ``sshpass`` has to be installed on the server where eNMS is running.
+For the multiplexing feature to work `tmux` has to be installed on the server where eNMS is running.
+
+
 
 Port allocation
 ---------------
 
-By default, eNMS will use the range of ports [9000, 9099]. eNMS uses a rotation system to allocate these ports sequentially as user requests come in.
+By default, eNMS will use the range of ports as defined in the 
+:ref:`ssh section <ssh-settings>` in the settings.
 
-You can change this range directly from the web UI, in the :guilabel:`Admin / Administration` page, button ``SSH Terminal``.
+eNMS uses a rotation system to allocate these ports sequentially as user requests come in.
+You can view this range directly from the web UI, via the :guilabel:`Settings` button on the top of the screen, 
+and selecting the ``ssh`` section.
+
+
 
 Custom URL
 ----------
 
 eNMS automatically redirects you to the address and port GoTTY is listening to,
 using JavaScript variables ``window.location.hostname`` and ``window.location.protocol``.
-If these variables do not redirect to the right URL, you can tell eNMS which protocol
-and URL to use by setting the ``address`` variable in the settings. (just the URL, and 
-eNMS will add the port GoTTY is listening to)
+If these variables do not redirect to the correct URL, you can tell eNMS which protocol
+and URL to use by changing the ``address`` variable in the :ref:`app section <app-settings>` in the settings (just the URL, and 
+eNMS will add the port GoTTY is listening to).
 
 Port redirection
 ----------------
 
 In a production environment, only one port should be allowed (to be exposed) by the HTTP web server. In that case, the reverse proxy must be configured to redirect the requests sent to ``terminal<port_number>`` to ``localhost:<port_number>``.
 
-With Nginx, this can be accomplished with the following `location` :
+With Nginx, this can be accomplished with the following `location` block :
 
 ::
 
@@ -48,35 +61,31 @@ With Nginx, this can be accomplished with the following `location` :
    proxy_set_header Connection "upgrade";
  }
 
-A full example of nginx configuration can be found in ``eNMS/files/nginx``.
+A full example of the nginx configuration can be found in ``eNMS/files/nginx``.
 
 eNMS does not by default perform any port redirection: you must set the ``port_redirection``
-variable to ``true`` to enable it.
+variable to ``true`` in the :ref:`ssh section <ssh-settings>` in the settings to enable it.
 
 Ignore fingerprint prompt
 -------------------------
 
-If the remote device is not in ``~/.ssh/known_hosts``, ``ssh`` prompts the user to add ssh fingerprint to ``known_hosts`` file, causing GoTTY to fail. To bypass that prompt, you can set the ``GOTTY_BYPASS_KEY_PROMPT`` to 1 to run the ``ssh`` command with the options ``-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null``.
+If the remote device is not in ``~/.ssh/known_hosts``, ``ssh`` prompts the user to add ssh fingerprint to ``known_hosts`` file, causing GoTTY to fail. 
+To bypass that prompt, you can set the ``bypass_key_prompt`` to ``true`` in the :ref:`ssh section <ssh-settings>` in the settings to run the ``ssh`` command with the options ``-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null``.
 
-::
-
- export GOTTY_BYPASS_KEY_PROMPT=1
-
-This is equivalent to adding the following lines in ``/etc/ssh_config``:
-
-::
-
- Host *
-     StrictHostKeyChecking no
-     UserKnownHostsFile /dev/null
 
 Connect to a device
 -------------------
 
+The connection dialog shows two options to connect to a device:
+
+- Web Session - allows the interaction with the device using the web browser on a separate tab.
+- Desktop Session - will generate and download a shortcut that will open the SSH client on the local PC.
+  Requires for the entire port range as defined in the :ref:`ssh section <ssh-settings>` in the settings to be accessible from the client.
+
 From the device management table
 ********************************
 
-You can connect to a device by clicking on the ``Connect`` button in :guilabel:`objects/device_management`.
+You can connect to a device by clicking on the ``Connect`` button next to each device entry in the :guilabel:`Inventory / Device` table as shown below.
 
 .. image:: /_static/inventory/web_connection/connect_from_device_management.png
    :alt: Connect buttons
@@ -90,7 +99,7 @@ The following window will pop up:
 
 You can configure the following parameters :
 
-- Property used for the connection: by default, eNMS uses the IP address but you can also tell him to use the name, or any custom property.
+- Property used for the connection: by default, eNMS uses the IP address but you can also select to use the name, or any custom property.
 - Accept only one client: the first client will be allowed, all others will be rejected when trying to access the terminal URL.
 - Share session with all clients: a single process will be shared across all clients with tmux (terminal multiplexing), such that all clients will share the same session (same screen).
 - Automatically authenticate (SSH only): eNMS will use the credentials stored in the Vault (production mode) or the database (test mode) to automatically authenticate to the network device. eNMS uses ``sshpass`` for the authentication: it must be installed if you activate the automatic authentication (``sudo apt-get install sshpass``). By default, eNMS uses the user credentials for the authentication (the ones you use to log in to eNMS). However, it can be configured to use the device credentials instead (the credentials that you can specify when creating a new device).
@@ -99,8 +108,7 @@ You can configure the following parameters :
 From the Views
 **************
 
-You can also connect to a device by clicking on the right-click menu entry ``Connect``:
+You can also connect to a device via the context menu in the geographical view in :guilabel:`Vizualization / Network View` and :guilabel:`Views / Site View`.
+Hover over a device (the cursor will change to an index finger with a device name pop-up), right click and select ``Connect``.
 
-- From the geographical view in :guilabel:`Views / Network View` and :guilabel:`Views / Site View`
-- From the pool logical visualization in :guilabel:`Inventory / Pool Management` (button ``Visualize``)
 


### PR DESCRIPTION
Updates to documentation.  In some cases heading markers have been extended beyond the current text.  It's valid for the heading markers to be longer than the heading text, but not shorter.  This simplifies our auto-docs-updates that change the length of some headings.