### PR TITLE
Netmiko services: Remove leading nulls from session_log

### DIFF
--- a/eNMS/services/data_validation/netmiko_prompts.py
+++ b/eNMS/services/data_validation/netmiko_prompts.py
@@ -76,7 +76,9 @@ class NetmikoPromptsService(ConnectionService):
                 **results,
                 **{
                     "error": format_exc(),
-                    "result": netmiko_connection.session_log.getvalue().decode(),
+                    "result": netmiko_connection.session_log.getvalue()
+                    .decode()
+                    .ltrim("\U0000"),
                     "match": confirmation,
                     "success": False,
                 },

--- a/eNMS/services/data_validation/netmiko_validation.py
+++ b/eNMS/services/data_validation/netmiko_validation.py
@@ -64,7 +64,9 @@ class NetmikoValidationService(ConnectionService):
             return {
                 "command": command,
                 "error": format_exc(),
-                "result": netmiko_connection.session_log.getvalue().decode(),
+                "result": netmiko_connection.session_log.getvalue()
+                .decode()
+                .ltrim("\U0000"),
                 "success": False,
             }
         return {"command": command, "result": result}


### PR DESCRIPTION
Netmiko includes "\U0000" in the session_log each time it attempts to read data from the socket.  The fix removes the unicode nulls from session_log when it's returned after a timeout.