### PR TITLE
Delete unicode nulls returned in the session_log after a timeout

### DIFF
--- a/eNMS/services/data_validation/netmiko_prompts.py
+++ b/eNMS/services/data_validation/netmiko_prompts.py
@@ -76,7 +76,9 @@ class NetmikoPromptsService(ConnectionService):
                 **results,
                 **{
                     "error": format_exc(),
-                    "result": netmiko_connection.session_log.getvalue().decode(),
+                    "result": netmiko_connection.session_log.getvalue()
+                    .decode()
+                    .lstrip("\u0000"),
                     "match": confirmation,
                     "success": False,
                 },

--- a/eNMS/services/data_validation/netmiko_validation.py
+++ b/eNMS/services/data_validation/netmiko_validation.py
@@ -64,7 +64,9 @@ class NetmikoValidationService(ConnectionService):
             return {
                 "command": command,
                 "error": format_exc(),
-                "result": netmiko_connection.session_log.getvalue().decode(),
+                "result": netmiko_connection.session_log.getvalue()
+                .decode()
+                .lstrip("\u0000"),
                 "success": False,
             }
         return {"command": command, "result": result}


### PR DESCRIPTION
Remove any \U0000's from Netmiko's session_log that gets returned on a timeout.  Netmiko includes a \U0000 for every time it checks the socket for more data from the remote system.