### PR TITLE
netmiko_prompts: Detect confirmation string in output

### DIFF
--- a/eNMS/services/data_validation/netmiko_prompts.py
+++ b/eNMS/services/data_validation/netmiko_prompts.py
@@ -61,15 +61,10 @@ class NetmikoPromptsService(ConnectionService):
                     logger="security",
                 )
                 confirmation = run.sub(expect_string, locals())
-                result = netmiko_connection.send_command_timing(
-                    command, delay_factor=run.delay_factor
+                result = netmiko_connection.send_command(
+                    command, expect_string=confirmation, delay_factor=run.delay_factor
                 )
                 results[command] = {"result": result, "match": confirmation}
-                if confirmation and confirmation not in result:
-                    results.update(
-                        {"success": False, "result": result, "match": confirmation}
-                    )
-                    return results
             run.exit_remote_device(netmiko_connection, prompt, device)
         except Exception:
             return {


### PR DESCRIPTION
Terminate wait for output when the confirmation text is seen or on timeout.  The previous implementation always waited for the timeout.

Previously working service started failing with an exception EOFError/bad file descriptor.  I suspect netmiko v3 changed the timeout behavior for send_command_timing.  This implementation runs faster for the sunny day scenario and also handles timeouts.