### PR TITLE
prevent textarea resize horizontally, added codemirror resize

### DIFF
--- a/eNMS/static/css/main.css
+++ b/eNMS/static/css/main.css
@@ -780,3 +780,14 @@ fieldset.section {
   -webkit-box-shadow: 0px 0px 0px 0px #000;
   box-shadow: 0px 0px 0px 0px #000;
 }
+
+/* enables resizing of code mirror content */
+.CodeMirror {
+  resize: vertical;  
+}
+
+/* prevents text area resizing in horizontal direction
+   to preserve layout. */
+textarea.form-control {
+  resize: vertical;
+}


### PR DESCRIPTION
Two visual improvemets.

1. Enable CodeMirror vertical resizing.
2. Prevent text area resizing in horizontal direction to preserver layout.