### PR TITLE
Moved {% set label %} to be just before the {% if values["type"] == "boolean" %}

### DIFF
--- a/eNMS/templates/forms/service.html
+++ b/eNMS/templates/forms/service.html
@@ -284,8 +284,8 @@
               aria-labelledby="heading-step1-3"
             >
               <div class="panel-body" style="background-color: #fafafa;">
-                {% for property, values in form.custom_properties.items() %} {% if
-                values["type"] == "boolean" %} {% set label %} {% if "render_kw" in
+                {% for property, values in form.custom_properties.items() %}
+                {% set label %} {% if "render_kw" in
                 values and "help" in values.get("render_kw", {}) %}
                 <label help="{{ values['render_kw']['help'] }}" for="{{ property }}">
                   {{ values["pretty_name"] }}
@@ -293,6 +293,7 @@
                 {% else %}
                 <label>{{ values["pretty_name"] }}</label>
                 {% endif %} {% endset %}
+                {% if values["type"] == "boolean" %}
                 <fieldset>
                   <div class="item">
                     {{ form[property](id="{}-{}".format(form_type, property),


### PR DESCRIPTION
I liked the set label for removing the duplicated code.

In recent testing, the custom properties for non-boolean types were not showing their labels.
I think the {% set label %} needs to be moved to be before that {% if values["type"] == "boolean" %}.
