### PR TITLE
use device_id for session name in tmux

### DIFF
--- a/eNMS/controller/inventory.py
+++ b/eNMS/controller/inventory.py
@@ -43,7 +43,7 @@ class InventoryController(BaseController):
         if "accept-once" in kwargs:
             cmd.append("--once")
         if "multiplexing" in kwargs:
-            cmd.extend(f"tmux new -A -s gotty{port}".split())
+            cmd.extend(f"tmux new -A -s gotty{device_id}".split())
         if self.settings["ssh"]["bypass_key_prompt"]:
             options = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
         else:


### PR DESCRIPTION
The tmux session name was using the gotty port which did not allow different clients to connect to the same session.
Replaced with device_id so the tmux session for different clients connecting to the same device is the same.
