### PR TITLE
Minor refreshTable selector adjustment

### DIFF
--- a/eNMS/static/js/table.js
+++ b/eNMS/static/js/table.js
@@ -1327,7 +1327,7 @@ function exportTable(tableId) {
 }
 
 export const refreshTable = function (tableId, notification) {
-  if ($(`#${tableId}`).length) tableInstances[tableId].table.ajax.reload(null, false);
+  if ($(`#table-${tableId}`).length) tableInstances[tableId].table.ajax.reload(null, false);
   if (notification) notify("Table refreshed.", "success", 5);
 };
 

--- a/eNMS/static/js/table.js
+++ b/eNMS/static/js/table.js
@@ -45,8 +45,8 @@ export class Table {
       orderCellsTop: true,
       autoWidth: false,
       scrollX: true,
-      drawCallback: function () {
-        $(".paginate_button > a").on("focus", function () {
+      drawCallback: function() {
+        $(".paginate_button > a").on("focus", function() {
           $(this).blur();
         });
         createTooltips();
@@ -54,10 +54,10 @@ export class Table {
       sDom: "tilp",
       columns: this.columns,
       columnDefs: [{ className: "dt-center", targets: "_all" }],
-      initComplete: function () {
+      initComplete: function() {
         this.api()
           .columns()
-          .every(function (index) {
+          .every(function(index) {
             const data = self.columns[index];
             let element;
             const elementId = `${self.type}_filtering-${data.data}`;
@@ -106,15 +106,15 @@ export class Table {
             }
             $(element)
               .appendTo($(this.header()))
-              .on("keyup change", function () {
+              .on("keyup change", function() {
                 if (waitForSearch) return;
                 waitForSearch = true;
-                setTimeout(function () {
+                setTimeout(function() {
                   self.table.page(0).ajax.reload(null, false);
                   waitForSearch = false;
                 }, 500);
               })
-              .on("click", function (e) {
+              .on("click", function(e) {
                 e.stopPropagation();
               });
           });
@@ -137,7 +137,7 @@ export class Table {
           Object.assign(d, self.filteringData);
           return JSON.stringify(d);
         },
-        dataSrc: function (result) {
+        dataSrc: function(result) {
           if (result.error) {
             notify(result.error, "error", 5);
             return [];
@@ -219,9 +219,13 @@ export class Table {
       );
     });
     $(`#column-display-${this.id}`).selectpicker("refresh");
-    $(`#column-display-${this.id}`).on("change", function () {
+    $(`#column-display-${this.id}`).on("change", function() {
       self.columns.forEach((col) => {
-        self.table.column(`${col.name}:name`).visible($(this).val().includes(col.data));
+        self.table.column(`${col.name}:name`).visible(
+          $(this)
+            .val()
+            .includes(col.data)
+        );
       });
       self.table.ajax.reload(null, false);
       self.createfilteringTooltips();
@@ -539,7 +543,7 @@ tables.configuration = class ConfigurationTable extends Table {
         formatter: (value) => `Lines of context: ${value}`,
         tooltip: "always",
       })
-      .on("change", function () {
+      .on("change", function() {
         refreshTable("configuration");
       });
   }
@@ -860,7 +864,7 @@ tables.service = class ServiceTable extends Table {
     loadServiceTypes();
     $("#parent-filtering")
       .selectpicker()
-      .on("change", function () {
+      .on("change", function() {
         self.table.page(0).ajax.reload(null, false);
       });
   }
@@ -1305,10 +1309,14 @@ tables.event = class EventTable extends Table {
   }
 };
 
-export const clearSearch = function (tableId, notification) {
+export const clearSearch = function(tableId, notification) {
   $(`.search-input-${tableId},.search-list-${tableId}`).val("");
-  $(".search-relation-dd").val("any").selectpicker("refresh");
-  $(".search-relation").val([]).trigger("change");
+  $(".search-relation-dd")
+    .val("any")
+    .selectpicker("refresh");
+  $(".search-relation")
+    .val([])
+    .trigger("change");
   $(`.search-select-${tableId}`).val("inclusion");
   refreshTable(tableId);
   if (notification) notify("Search parameters cleared.", "success", 5);
@@ -1326,8 +1334,9 @@ function exportTable(tableId) {
   refreshTable(tableId);
 }
 
-export const refreshTable = function (tableId, notification) {
-  if ($(`#table-${tableId}`).length) tableInstances[tableId].table.ajax.reload(null, false);
+export const refreshTable = function(tableId, notification) {
+  if ($(`#table-${tableId}`).length)
+    tableInstances[tableId].table.ajax.reload(null, false);
   if (notification) notify("Table refreshed.", "success", 5);
 };
 
@@ -1365,7 +1374,7 @@ function bulkDeletion(tableId, model) {
   call({
     url: `/bulk_deletion/${model}`,
     form: `search-form-${tableId}`,
-    callback: function (number) {
+    callback: function(number) {
       refreshTable(tableId);
       $(`#bulk_deletion-${tableId}`).remove();
       notify(`${number} items deleted.`, "success", 5, true);
@@ -1378,7 +1387,7 @@ function bulkRemoval(tableId, model, instance) {
   call({
     url: `/bulk_removal/${model}/${instance.type}/${instance.id}/${relation}`,
     form: `search-form-${tableId}`,
-    callback: function (number) {
+    callback: function(number) {
       refreshTable(tableId);
       notify(
         `${number} ${model}s removed from ${instance.type} '${instance.name}'.`,
@@ -1394,7 +1403,7 @@ function bulkEdit(formId, model, table) {
   call({
     url: `/bulk_edit/${model}`,
     form: `${formId}-form`,
-    callback: function (number) {
+    callback: function(number) {
       refreshTable(table);
       $(`#${formId}`).remove();
       notify(`${number} items modified.`, "success", 5, true);
@@ -1429,7 +1438,7 @@ function displayRelationTable(type, instance, relation) {
     id: instance.id,
     size: "1200 600",
     title: `${instance.name} - ${type}s`,
-    callback: function () {
+    callback: function() {
       const constraints = { [`${relation.from}`]: [instance.id] };
       // eslint-disable-next-line new-cap
       new tables[type](instance.id, constraints, { relation, ...instance });


### PR DESCRIPTION
When testing earlier changes, the periodic table refresh did not seem to work.
In the code, below, 'run' is being passed in as `tableId`, but the selector for the table appeared to be `"#table-run"`
