### PR TITLE
Allow retrieval of all device config fields

### DIFF
--- a/eNMS/server.py
+++ b/eNMS/server.py
@@ -391,7 +391,8 @@ class Server(Flask):
             decorators = [self.auth.login_required, self.monitor_rest_request]
 
             def get(self, name):
-                return db.fetch("device", name=name).configuration
+                config_name = request.args.to_dict().get("config_name", "configuration")
+                return getattr(db.fetch("device", name=name), config_name)
 
         class GetResult(Resource):
             decorators = [self.auth.login_required, self.monitor_rest_request]

--- a/eNMS/server.py
+++ b/eNMS/server.py
@@ -391,8 +391,8 @@ class Server(Flask):
             decorators = [self.auth.login_required, self.monitor_rest_request]
 
             def get(self, name):
-                config_name = request.args.to_dict().get("config_name", "configuration")
-                return getattr(db.fetch("device", name=name), config_name)
+                property = request.args.to_dict().get("property", "configuration")
+                return getattr(db.fetch("device", name=name), property)
 
         class GetResult(Resource):
             decorators = [self.auth.login_required, self.monitor_rest_request]


### PR DESCRIPTION
Added query parameter config_name to /rest/configuration.  Config_name specifies which device config property to return.  The default is "configuration" which provides backward compatible behavior.