### PR TITLE
Minor fix to honor config_mode in the service.

### DIFF
--- a/eNMS/services/configuration/netmiko_configuration.py
+++ b/eNMS/services/configuration/netmiko_configuration.py
@@ -41,6 +41,7 @@ class NetmikoConfigurationService(ConnectionService):
         )
         netmiko_connection.send_config_set(
             config.splitlines(),
+            enter_config_mode=run.config_mode,
             delay_factor=run.delay_factor,
             exit_config_mode=run.exit_config_mode,
             strip_prompt=run.strip_prompt,


### PR DESCRIPTION
Config mode is always being entered into, even when the box is unchecked. Adding this line will allow users to decide if they do not want to enter config mode. 