### PR TITLE
workflowBuilder.js: restored iteration hover after change in vis.js

### DIFF
--- a/eNMS/static/js/workflowBuilder.js
+++ b/eNMS/static/js/workflowBuilder.js
@@ -507,6 +507,8 @@ function drawIterationEdge(service) {
       title += `<b>Iteration Values</b>: ${service.iteration_values}<br>`;
     }
     title += `<b>Iteration Variable Name</b>: ${service.iteration_variable_name}`;
+    const hoverDiv = document.createElement("div");
+    hoverDiv.innerHTML = title;
     {
       edges.add({
         id: -service.id,
@@ -515,7 +517,7 @@ function drawIterationEdge(service) {
         to: service.id,
         color: "black",
         arrows: { to: { enabled: true } },
-        title: title,
+        title: hoverDiv,
         font: { vadjust: -15 },
       });
     }


### PR DESCRIPTION
Allow HTML in the iteration label in the Workflow Builder