### PR TITLE
Confirmation Panel & workflow_stop modifications

### DIFF
--- a/eNMS/controller.py
+++ b/eNMS/controller.py
@@ -1129,10 +1129,10 @@ class Controller:
         if run and run.status == "Running":
             if user_name != run.creator and not confirm_stop:
                 return run.creator
-            if self.redis_queue:
-                self.redis("set", f"stop/{run.parent_runtime}", "true")
+            if env.redis_queue:
+                env.redis("set", f"stop/{run.parent_runtime}", "true")
             else:
-                self.run_stop[run.parent_runtime] = True
+                vs.run_stop[run.parent_runtime] = True
             return True
 
     def switch_menu(self, user_id):

--- a/eNMS/controller.py
+++ b/eNMS/controller.py
@@ -1123,13 +1123,16 @@ class Controller:
             "update_time": workflow.last_modified,
         }
 
-    def stop_workflow(self, runtime):
+    def stop_workflow(self, runtime, confirm_stop=False):
         run = db.fetch("run", allow_none=True, runtime=runtime)
+        user_name = getattr(current_user, "name", "")
         if run and run.status == "Running":
-            if env.redis_queue:
-                env.redis("set", f"stop/{run.parent_runtime}", "true")
+            if user_name != run.creator and not confirm_stop:
+                return run.creator
+            if self.redis_queue:
+                self.redis("set", f"stop/{run.parent_runtime}", "true")
             else:
-                vs.run_stop[run.parent_runtime] = True
+                self.run_stop[run.parent_runtime] = True
             return True
 
     def switch_menu(self, user_id):

--- a/eNMS/static/js/base.js
+++ b/eNMS/static/js/base.js
@@ -322,6 +322,42 @@ export function openPanel({
   $(panel).css({ ...position, ...css });
 }
 
+export function showConfirmationPanel({ 
+  title, 
+  message, 
+  confirmText="OK", 
+  cancelText="Cancel", 
+  onConfirm, 
+  onCancel 
+}) {
+  var content = `
+  <div class="modal-body" style="max-width:400px">
+    ${message}
+  </div>
+  <div class="modal-footer">
+    <center>
+      <button type="button" class="btn cancelAction">${cancelText}</button>
+      <button type="button" class="btn btn-danger confirmAction">${confirmText}</button>
+    </center>
+  </div><br>`;
+  var idNum = Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
+  var panelName =  `confirmation_modal-${idNum}`;
+  openPanel({
+    name: panelName,
+    title: title,
+    content: content,
+    size: "auto",
+  });
+  $(".confirmAction").click(function () {
+    if (typeof onConfirm === "function") onConfirm();
+    $(`#${panelName}`).remove();
+  });
+  $(".cancelAction, .jsPanel-btn-close").click(function () {
+    if (typeof onCancel === "function") onCancel();
+    $(`#${panelName}`).remove();
+  });
+}
+
 export function createTooltip({
   name,
   target,

--- a/eNMS/static/js/base.js
+++ b/eNMS/static/js/base.js
@@ -323,10 +323,10 @@ export function openPanel({
 }
 
 export function showConfirmationPanel({ 
+  id,
   title, 
   message, 
   confirmText="OK", 
-  cancelText="Cancel", 
   onConfirm, 
   onCancel 
 }) {
@@ -336,12 +336,10 @@ export function showConfirmationPanel({
   </div>
   <div class="modal-footer">
     <center>
-      <button type="button" class="btn cancelAction">${cancelText}</button>
       <button type="button" class="btn btn-danger confirmAction">${confirmText}</button>
     </center>
   </div><br>`;
-  var idNum = Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
-  var panelName =  `confirmation_modal-${idNum}`;
+  var panelName = `confirmation_modal-${id}`;
   openPanel({
     name: panelName,
     title: title,

--- a/eNMS/static/js/workflowBuilder.js
+++ b/eNMS/static/js/workflowBuilder.js
@@ -400,15 +400,32 @@ function saveEdge(edge) {
 }
 
 function stopWorkflow() {
+  const processResponse = function (result) {
+    if (!result) {
+      notify("The workflow is not currently running.", "error", 5);
+    } else if (typeof result === "string") {
+      return result
+    } else {
+      notify("Workflow will stop after current service...", "success", 5);
+    }
+  }
   call({
     url: `/stop_workflow/${currentRuntime}`,
     callback: (result) => {
-      if (!result) {
-        notify("The workflow is not currently running.", "error", 5);
-      } else {
-        notify("Workflow will stop after current service...", "success", 5);
+      let otherUser = processResponse(result);
+      if (otherUser) {
+        showConfirmationPanel({
+          title: "Please Confirm Workflow Stop",
+          message: `The current runtime of this workflow was started by '${otherUser}'.\nPlease confirm you would still like to stop it.`,
+          onConfirm: () => {
+            call({
+              url: `/stop_workflow/${currentRuntime}/true`,
+              callback: (result) => {processResponse(result)}
+            });
+          }
+        });
       }
-    },
+    }
   });
 }
 

--- a/eNMS/static/js/workflowBuilder.js
+++ b/eNMS/static/js/workflowBuilder.js
@@ -414,7 +414,7 @@ function stopWorkflow() {
       }
     });
   }
-  if (currentRun && user.name !== currentRun?.creator) {
+  if (currentRun?.status === "Running" && user.name !== currentRun?.creator) {
     showConfirmationPanel({
       id: currentRun.id,
       title: "Please Confirm Workflow Stop",

--- a/eNMS/static/js/workflowBuilder.js
+++ b/eNMS/static/js/workflowBuilder.js
@@ -22,6 +22,7 @@ import {
   openPanel,
   showInstancePanel,
   userIsActive,
+  showConfirmationPanel,
 } from "./base.js";
 import { clearSearch, tables, tableInstances } from "./table.js";
 


### PR DESCRIPTION
The workflow_stop endpoint now checks the current user against the runtime's creator by default, with an optional override. 

This new functionality is implemented in `workflowBuilder.js` using the added `showConfirmationPanel()` function in `base.js`, which opens a simple jsPanel prompting the user to continue if they truly intend to stop another user's workflow.