### PR TITLE
Confirmation panel RBAC bugfix

### DIFF
--- a/eNMS/static/js/base.js
+++ b/eNMS/static/js/base.js
@@ -345,6 +345,7 @@ export function showConfirmationPanel({
     title: title,
     content: content,
     size: "auto",
+    checkRbac: false
   });
   $(".confirmAction").click(function () {
     if (typeof onConfirm === "function") onConfirm();


### PR DESCRIPTION
Discovered that the confirmation panel `openPanel()` call was resulting in "403 - Operation not allowed" errors from user accounts. Added `checkRbac: false` to bypass the search for endpoint/form access that doesn't exist. 